### PR TITLE
Fix @FactoryMethod causing exceptions in ReferenceResolver

### DIFF
--- a/yajco-annotations/src/main/java/yajco/ReferenceResolver.java
+++ b/yajco-annotations/src/main/java/yajco/ReferenceResolver.java
@@ -107,7 +107,7 @@ public class ReferenceResolver {
      * @param objects  child AST nodes
      * @return the same object as passed by parameter object
      */
-    private <T> T register(T object, String methodName, Object... objects) {
+    public <T> T register(T object, String methodName, Object... objects) {
         registeredObjects.add(object);
         analyzeConstructor(object, methodName, objects);
         createXmlNode(object, objects);


### PR DESCRIPTION
The Optional PR broke factory method handling in `ReferenceResolver`: https://github.com/kpi-tuke/yajco/commit/6c946041df88698bc57bd92ccda2d648222678c7#diff-73abf42dedb45e7b15dddb580c045335R110. For some reason it privatized the second `register` overload which actually _is_ used from outside (in semantic actions).

For the record, this is the error I was getting:

```
java.lang.RuntimeException: Suitable constructor does not exist 'class yajco.example.testLang.model.Opt' for values [Opt]
    at yajco.ReferenceResolver.findConstructor (ReferenceResolver.java:416)
    at yajco.ReferenceResolver.analyzeConstructor (ReferenceResolver.java:317)
    at yajco.ReferenceResolver.register (ReferenceResolver.java:112)
    at yajco.ReferenceResolver.register (ReferenceResolver.java:99)
    at yajco.example.testLang.parser.antlr4.TestLangParserParser.nt_opt (TestLangParserParser.java:225)
    at yajco.example.testLang.parser.antlr4.TestLangParserParser.nt_bc (TestLangParserParser.java:186)
    at yajco.example.testLang.parser.antlr4.TestLangParserParser.nt_input (TestLangParserParser.java:145)
    at yajco.example.testLang.parser.antlr4.TestLangParserParser.main (TestLangParserParser.java:103)
    at yajco.example.testLang.parser.TestLangParser.parse (TestLangParser.java:17)
    at yajco.example.testLang.Main.main (Main.java:10)
    at jdk.internal.reflect.NativeMethodAccessorImpl.invoke0 (Native Method)
    at jdk.internal.reflect.NativeMethodAccessorImpl.invoke (NativeMethodAccessorImpl.java:62)
    at jdk.internal.reflect.DelegatingMethodAccessorImpl.invoke (DelegatingMethodAccessorImpl.java:43)
    at java.lang.reflect.Method.invoke (Method.java:566)
    at org.codehaus.mojo.exec.ExecJavaMojo$1.run (ExecJavaMojo.java:282)
    at java.lang.Thread.run (Thread.java:834)

```