### PR TITLE
[Refactoring] Fix generic return type

### DIFF
--- a/yajco-model/src/main/java/yajco/model/pattern/PatternSupport.java
+++ b/yajco-model/src/main/java/yajco/model/pattern/PatternSupport.java
@@ -1,15 +1,16 @@
 package yajco.model.pattern;
 
-import java.util.ArrayList;
-import java.util.List;
 import yajco.model.YajcoModelElement;
 
+import java.util.ArrayList;
+import java.util.List;
+
 public class PatternSupport<T extends Pattern> extends YajcoModelElement {
-    private List<T> patterns;
+    private final List<T> patterns;
 
     public PatternSupport(Object sourceElement) {
         super(sourceElement);
-        this.patterns = new ArrayList<T>();
+        this.patterns = new ArrayList<>();
     }
 
     public PatternSupport(List<T> patterns, Object sourceElement) {
@@ -25,12 +26,22 @@ public class PatternSupport<T extends Pattern> extends YajcoModelElement {
         patterns.add(pattern);
     }
 
-    //public T getPattern(Class<? extends Pattern> clazz) {
-    //public <R extends T> T getPattern(Class<R> clazz) {
-    public T getPattern(Class<? extends T> clazz) {
+    /**
+     * Get a pattern of <b>exactly</b> the given type from the patterns contained in this object.
+     * For example {@link yajco.model.Concept Concept} has {@link ConceptPattern ConceptPatterns} (type T)
+     * and you want to get an {@link yajco.model.pattern.impl.Operator Operator pattern} (type R - a subtype of
+     * ConceptPattern). The returned pattern is already cast to the requested type R.
+     *
+     * @param clazz class of the pattern you are searching
+     * @param <R>   Type of the pattern you are looking for.
+     *              It can be any subtype of {@link T} held in this object.
+     * @return searched pattern if present, otherwise null
+     */
+    public <R extends T> R getPattern(Class<R> clazz) {
         for (T pattern : patterns) {
             if (pattern.getClass().equals(clazz)) {
-                return pattern;
+                //noinspection unchecked
+                return (R) pattern;
             }
         }
 


### PR DESCRIPTION
Return the pattern cast to the requested type, so a type cast is not needed everywhere after calling this method. The change is type sound.
Also some refactoring & javadoc.