### PR TITLE
[Fix] Printer optional unboxing

### DIFF
--- a/yajco-generator-tools/src/main/resources/yajco/generator/printergen/templates/Printer.java.vm
+++ b/yajco-generator-tools/src/main/resources/yajco/generator/printergen/templates/Printer.java.vm
@@ -95,6 +95,8 @@ public class $className extends ${visitorClassName}<PrintWriter> {
      #if(${Utilities.getClassName($type)} == $optionalTypeClassName)
         #set( $type = $type.componentType)
         #set( $getterExpr = "unwrapOptional(${getterExpr})")
+        ## Ignore missing optional property
+        && ( ${getterExpr} == null || (true
      #end
      #set( $className = ${Utilities.getClassName($type)} )
      #if( $className == $arrayTypeClassName || $className == $listTypeClassName || $className == $setTypeClassName)
@@ -133,6 +135,10 @@ public class $className extends ${visitorClassName}<PrintWriter> {
      #else
         $Utilities.throwGeneratorException("Not known type for ${property.name}")
         // not known type for ${property.name}
+     #end
+     #if(${Utilities.getClassName($property.type)} == $optionalTypeClassName)
+         ## close parentheses for optional properties
+         ))
      #end
     #end
    #end

--- a/yajco-generator-tools/src/main/resources/yajco/generator/printergen/templates/Printer.java.vm
+++ b/yajco-generator-tools/src/main/resources/yajco/generator/printergen/templates/Printer.java.vm
@@ -1,16 +1,16 @@
 #set( $nameMap = ${Utilities.createConceptUniqueNames($language)} )
 package ${ModelUtilities.getLanguagePackageName($language)}.$package;
 
+#foreach( $concept in ${Utilities.getConceptsNeededForImport($nameMap)} )
+import ${ModelUtilities.getFullConceptClassName($language, $concept)};
+#end
+import ${ModelUtilities.getLanguagePackageName($language)}.${visitorPackage}.${visitorClassName};
+
+import java.io.PrintWriter;
 import java.util.List;
 import java.util.Set;
 import java.util.HashMap;
 import java.util.Map;
-import java.io.PrintWriter;
-import ${ModelUtilities.getLanguagePackageName($language)}.${visitorPackage}.${visitorClassName};
-
-#foreach( $concept in ${Utilities.getConceptsNeededForImport($nameMap)} )
-import ${ModelUtilities.getFullConceptClassName($language, $concept)};
-#end
 
 public class $className extends ${visitorClassName}<PrintWriter> {
 #if ( !$language.skips.isEmpty() )
@@ -34,6 +34,9 @@ public class $className extends ${visitorClassName}<PrintWriter> {
 #foreach( $concept in $language.concepts )
     @Override
     protected void visit${Utilities.getMethodPartName($nameMap, $concept)}(${Utilities.getClassName($nameMap, $concept)} ${Utilities.toLowerCaseIdent($concept.conceptName)}, PrintWriter p) {
+        if (${Utilities.toLowerCaseIdent($concept.conceptName)} == null) {
+            return;
+        }
  #set( $conceptPatterns = ${concept.patterns} )
  #set( $hasEnumPattern = ${Utilities.hasClassInList(${conceptPatterns},${enumPatternClassName})} )
  #set( $hasClassIndentPattern = ${Utilities.hasClassInList(${conceptPatterns},${indentPatternClassName})} )
@@ -91,7 +94,7 @@ public class $className extends ${visitorClassName}<PrintWriter> {
      #set( $getterExpr = "${Utilities.toLowerCaseIdent($concept.conceptName)}.get${Utilities.toUpperCaseIdent($property.name)}()")
      #if(${Utilities.getClassName($type)} == $optionalTypeClassName)
         #set( $type = $type.componentType)
-        #set( $getterExpr = "${getterExpr}.orElse(null)")
+        #set( $getterExpr = "unwrapOptional(${getterExpr})")
      #end
      #set( $className = ${Utilities.getClassName($type)} )
      #if( $className == $arrayTypeClassName || $className == $listTypeClassName || $className == $setTypeClassName)
@@ -185,6 +188,9 @@ public class $className extends ${visitorClassName}<PrintWriter> {
    #if( ${Utilities.getClassName($type.componentType)} == $referenceTypeClassName )
     @Override
     protected void visit${Utilities.toUpperCaseIdent($property.name)}In${Utilities.getMethodPartName($nameMap, $concept)}(#writeSpecifiedType($type ${Utilities.getClassName($nameMap, $type.componentType.concept)}) ${Utilities.toLowerCaseIdent($property.name)}, PrintWriter p) {
+           if (${Utilities.toLowerCaseIdent($property.name)} == null) {
+               return;
+           }
     #set( $patterns = ${ModelUtilities.getAllPatterns(${property},${concept})} )
     #set( $separator = false )
     #set( $separator = ${Utilities.getObjectFromList(${patterns},${separatorPatternClassName})} )
@@ -324,6 +330,10 @@ public class $className extends ${visitorClassName}<PrintWriter> {
 ##
 ##
 #macro( processNotationPart $notationPart )
+   #set( $property = ${ModelUtilities.getPropertyFromNotationPart(${notationPart},${concept})} )
+   #if( $property )
+    #set( $getterExpr = "${Utilities.toLowerCaseIdent($concept.conceptName)}.get${Utilities.toUpperCaseIdent($property.name)}()")
+   #end
    #set( $hasPatternSupport = ${Utilities.instanceOf(${notationPart},${patternSupportClassName})} )
    #if( $hasPatternSupport )
     #set( $hasNewLinePattern = ${Utilities.hasClassInList(${notationPart.patterns},${newLinePatternClassName})} )
@@ -340,12 +350,10 @@ public class $className extends ${visitorClassName}<PrintWriter> {
    #if( $notationPartClassName == $tokenPartClassName )
         printLiteral("${notationPart.token}", p);
    #elseif( $notationPartClassName == $propertyReferencePartClassName || $notationPartClassName == $localVariablePartClassName)
-    #set( $property = ${ModelUtilities.getPropertyFromNotationPart(${notationPart},${concept})} )
     #set( $type = ${property.type} )
-    #set( $getterExpr = "${Utilities.toLowerCaseIdent($concept.conceptName)}.get${Utilities.toUpperCaseIdent($property.name)}()")
     #if(${Utilities.getClassName($type)} == $optionalTypeClassName)
        #set( $type = $type.componentType)
-       #set( $getterExpr = "${getterExpr}.orElse(null)")
+       #set( $getterExpr = "unwrapOptional(${getterExpr})")
     #end
     #set( $className = ${Utilities.getClassName($type)} )
     #if( $className == $arrayTypeClassName || $className == $listTypeClassName || $className == $setTypeClassName)
@@ -371,9 +379,11 @@ public class $className extends ${visitorClassName}<PrintWriter> {
         // not known type for ${property.name}
     #end
    #elseif( $notationPartClassName == $optionalPartClassName )
+       if (unwrapOptional(${getterExpr}) != null) {
        #foreach( $notationPart in $notationPart.parts )
            #processNotationPart( $notationPart )
        #end
+       }
    #else
         // not known type for NotationType
    #end

--- a/yajco-generator-tools/src/main/resources/yajco/generator/printergen/templates/Printer.java.vm
+++ b/yajco-generator-tools/src/main/resources/yajco/generator/printergen/templates/Printer.java.vm
@@ -88,43 +88,45 @@ public class $className extends ${visitorClassName}<PrintWriter> {
     #if( ${ModelUtilities.getPropertyFromNotationPart(${notationPart},${concept})} )
      #set( $property = ${ModelUtilities.getPropertyFromNotationPart(${notationPart},${concept})} )
      #set( $type = ${property.type} )
-        #if(${Utilities.getClassName($type)} == $optionalTypeClassName)
-            #set( $type = $type.componentType)
-        #end
+     #set( $getterExpr = "${Utilities.toLowerCaseIdent($concept.conceptName)}.get${Utilities.toUpperCaseIdent($property.name)}()")
+     #if(${Utilities.getClassName($type)} == $optionalTypeClassName)
+        #set( $type = $type.componentType)
+        #set( $getterExpr = "${getterExpr}.orElse(null)")
+     #end
      #set( $className = ${Utilities.getClassName($type)} )
      #if( $className == $arrayTypeClassName || $className == $listTypeClassName || $className == $setTypeClassName)
       #set( $hasRangePattern = ${Utilities.hasClassInList(${notationPart.patterns},${rangePatternClassName})} )
       #set( $rangePattern = ${Utilities.getObjectFromList(${notationPart.patterns},${rangePatternClassName})} )
       #if( ${Utilities.getClassName($type.componentType)} == $referenceTypeClassName )
-          && ${Utilities.toLowerCaseIdent($concept.conceptName)}.get${Utilities.toUpperCaseIdent($property.name)}() != null
+          && $getterExpr != null
        #if( $hasRangePattern )
          #if( $className == $arrayTypeClassName )
-          && ${Utilities.toLowerCaseIdent($concept.conceptName)}.get${Utilities.toUpperCaseIdent($property.name)}().length >= ${rangePattern.minOccurs}
+          && ${getterExpr}.length >= ${rangePattern.minOccurs}
          #else
-          && ${Utilities.toLowerCaseIdent($concept.conceptName)}.get${Utilities.toUpperCaseIdent($property.name)}().size() >= ${rangePattern.minOccurs}
+          && ${getterExpr}.size() >= ${rangePattern.minOccurs}
          #end
         #if( $rangePattern.maxOccurs != $rangePatternInfinityValue )
          #if( $className == $arrayTypeClassName )
-          && ${Utilities.toLowerCaseIdent($concept.conceptName)}.get${Utilities.toUpperCaseIdent($property.name)}().length <= ${rangePattern.maxOccurs}
+          && ${getterExpr}.length <= ${rangePattern.maxOccurs}
          #else
-          && ${Utilities.toLowerCaseIdent($concept.conceptName)}.get${Utilities.toUpperCaseIdent($property.name)}().size() <= ${rangePattern.maxOccurs}
+          && ${getterExpr}.size() <= ${rangePattern.maxOccurs}
          #end
         #end
        #else
          #if( $className == $arrayTypeClassName )
-          && ${Utilities.toLowerCaseIdent($concept.conceptName)}.get${Utilities.toUpperCaseIdent($property.name)}().length > 0
+          && ${getterExpr}.length > 0
          #else
-          && !${Utilities.toLowerCaseIdent($concept.conceptName)}.get${Utilities.toUpperCaseIdent($property.name)}().isEmpty()
+          && !${getterExpr}.isEmpty()
          #end
        #end
       #end
      #elseif( $className == $primitiveTypeClassName )
       #if( ${ModelUtilities.isStringType(${type})} )
-          && ${Utilities.toLowerCaseIdent($concept.conceptName)}.get${Utilities.toUpperCaseIdent($property.name)}() != null
+          && $getterExpr != null
       #end
       ## stale to musi mat nejaku hodnotu pri int, real, boolean, cize netreba dalej kontrolovat
      #elseif( $className == $referenceTypeClassName )
-           && ${Utilities.toLowerCaseIdent($concept.conceptName)}.get${Utilities.toUpperCaseIdent($property.name)}() != null
+           && $getterExpr != null
      #else
         $Utilities.throwGeneratorException("Not known type for ${property.name}")
         // not known type for ${property.name}
@@ -340,13 +342,15 @@ public class $className extends ${visitorClassName}<PrintWriter> {
    #elseif( $notationPartClassName == $propertyReferencePartClassName || $notationPartClassName == $localVariablePartClassName)
     #set( $property = ${ModelUtilities.getPropertyFromNotationPart(${notationPart},${concept})} )
     #set( $type = ${property.type} )
-       #if(${Utilities.getClassName($type)} == $optionalTypeClassName)
-           #set( $type = $type.componentType)
-       #end
+    #set( $getterExpr = "${Utilities.toLowerCaseIdent($concept.conceptName)}.get${Utilities.toUpperCaseIdent($property.name)}()")
+    #if(${Utilities.getClassName($type)} == $optionalTypeClassName)
+       #set( $type = $type.componentType)
+       #set( $getterExpr = "${getterExpr}.orElse(null)")
+    #end
     #set( $className = ${Utilities.getClassName($type)} )
     #if( $className == $arrayTypeClassName || $className == $listTypeClassName || $className == $setTypeClassName)
      #if( ${Utilities.getClassName($type.componentType)} == $referenceTypeClassName )
-        visit${Utilities.toUpperCaseIdent($property.name)}In${Utilities.getMethodPartName($nameMap, $concept)}(${Utilities.toLowerCaseIdent($concept.conceptName)}.get${Utilities.toUpperCaseIdent($property.name)}(), p);
+        visit${Utilities.toUpperCaseIdent($property.name)}In${Utilities.getMethodPartName($nameMap, $concept)}($getterExpr, p);
      #end
     #elseif( $className == $primitiveTypeClassName )
         printLiteral(${Utilities.toLowerCaseIdent($concept.conceptName)}.get${Utilities.toUpperCaseIdent($notationPart.property.name)}(), p);
@@ -354,13 +358,13 @@ public class $className extends ${visitorClassName}<PrintWriter> {
      #if( $notationPartClassName == $localVariablePartClassName )
       ## je potrebne vypisat len hodnotu z Identifier property, kedze je to referencovane len menom v originali
       #set( $propertyWithIdentifier = ${ModelUtilities.getIdentifierProperty(${type.concept})} )
-        printLiteral(${Utilities.toLowerCaseIdent($concept.conceptName)}.get${Utilities.toUpperCaseIdent($property.name)}().get${Utilities.toUpperCaseIdent(${propertyWithIdentifier.name})}(), p);
+        printLiteral(${getterExpr}.get${Utilities.toUpperCaseIdent(${propertyWithIdentifier.name})}(), p);
      #else
 ##      #set( $hasLocalParenthesesPattern = ${Utilities.hasClassInList(${$type.concept.patterns},${parenthesesPatternClassName})} )
 ##        #if ( $hasLocalParenthesesPattern )
 ##
 ##        #end
-        visit${Utilities.getMethodPartName($nameMap, $type.concept)}(${Utilities.toLowerCaseIdent($concept.conceptName)}.get${Utilities.toUpperCaseIdent($property.name)}(), p);
+        visit${Utilities.getMethodPartName($nameMap, $type.concept)}($getterExpr, p);
      #end
     #else
         $Utilities.throwGeneratorException("Not known type for ${property.name}")

--- a/yajco-generator-tools/src/main/resources/yajco/generator/visitorgen/templates/Visitor.java.vm
+++ b/yajco-generator-tools/src/main/resources/yajco/generator/visitorgen/templates/Visitor.java.vm
@@ -37,7 +37,7 @@ public class ${className}<P> {
 #set ( $getterExpr = "${Utilities.toLowerCaseIdent($concept.conceptName)}.get${Utilities.toUpperCaseIdent($property.name)}()")
 #if(${Utilities.getClassName($type)} == $optionalTypeClassName)
 #set( $type = $type.componentType)
-#set( $getterExpr = "(${getterExpr}.isPresent() ? ${getterExpr}.get() : null)")
+#set( $getterExpr = "${getterExpr}.orElse(null)")
 #end
 #set( $className = ${Utilities.getClassName($type)} )
 #if( $className == $arrayTypeClassName || $className == $listTypeClassName || $className == $setTypeClassName)

--- a/yajco-generator-tools/src/main/resources/yajco/generator/visitorgen/templates/Visitor.java.vm
+++ b/yajco-generator-tools/src/main/resources/yajco/generator/visitorgen/templates/Visitor.java.vm
@@ -2,13 +2,16 @@
 ##
 #set( $nameMap = ${Utilities.createConceptUniqueNames($language)} )
 package ${ModelUtilities.getLanguagePackageName($language)}.$package;
-import java.util.HashSet;
-import java.util.List;
-import java.util.Set;
-import yajco.visitor.VisitorException;
+
 #foreach( $concept in ${Utilities.getConceptsNeededForImport($nameMap)} )
 import ${ModelUtilities.getFullConceptClassName($language, $concept)};
 #end
+import yajco.visitor.VisitorException;
+
+import java.util.HashSet;
+import java.util.List;
+import java.util.Optional;
+import java.util.Set;
 
 public class ${className}<P> {
     protected Set<Object> visited = new HashSet<Object>();
@@ -37,7 +40,7 @@ public class ${className}<P> {
 #set ( $getterExpr = "${Utilities.toLowerCaseIdent($concept.conceptName)}.get${Utilities.toUpperCaseIdent($property.name)}()")
 #if(${Utilities.getClassName($type)} == $optionalTypeClassName)
 #set( $type = $type.componentType)
-#set( $getterExpr = "${getterExpr}.orElse(null)")
+#set( $getterExpr = "unwrapOptional(${getterExpr})")
 #end
 #set( $className = ${Utilities.getClassName($type)} )
 #if( $className == $arrayTypeClassName || $className == $listTypeClassName || $className == $setTypeClassName)
@@ -89,6 +92,9 @@ public class ${className}<P> {
 #if( $className == $arrayTypeClassName || $className == $listTypeClassName || $className == $setTypeClassName)
 #if( ${Utilities.getClassName($type.componentType)} == $referenceTypeClassName )
     protected void visit${Utilities.toUpperCaseIdent($property.name)}In${Utilities.getMethodPartName($nameMap, $concept)}(#writeSpecifiedType($type ${Utilities.getClassName($nameMap, $type.componentType.concept)}) ${Utilities.toLowerCaseIdent($property.name)}, P p) {
+        if (${Utilities.toLowerCaseIdent($property.name)} == null) {
+            return;
+        }
         for (${Utilities.getClassName($nameMap, $type.componentType.concept)} ${Utilities.toLowerCaseIdent($type.componentType.concept.conceptName)} : ${Utilities.toLowerCaseIdent($property.name)}) {
             if (enterVisit(${Utilities.toLowerCaseIdent($type.componentType.concept.conceptName)})) {
                 visit${Utilities.getMethodPartName($nameMap, $type.componentType.concept)}(${Utilities.toLowerCaseIdent($type.componentType.concept.conceptName)}, p);
@@ -120,6 +126,14 @@ public class ${className}<P> {
 
     protected boolean exitVisit(Object o) {
         return visited.remove(o);
+    }
+
+    protected <T> T unwrapOptional(Optional<T> optional){
+        return optional.orElse(null);
+    }
+
+    protected <T> T unwrapOptional(T nonOptional){
+        return nonOptional;
     }
 }
 ##

--- a/yajco-generator-tools/src/main/resources/yajco/generator/visitorgen/templates/Visitor.java.vm
+++ b/yajco-generator-tools/src/main/resources/yajco/generator/visitorgen/templates/Visitor.java.vm
@@ -42,24 +42,24 @@ public class ${className}<P> {
 #set( $className = ${Utilities.getClassName($type)} )
 #if( $className == $arrayTypeClassName || $className == $listTypeClassName || $className == $setTypeClassName)
 #if( ${Utilities.getClassName($type.componentType)} == $referenceTypeClassName )
-        visit${Utilities.toUpperCaseIdent($property.name)}In${Utilities.getMethodPartName($nameMap, $concept)}($getterExpr, p);
+            visit${Utilities.toUpperCaseIdent($property.name)}In${Utilities.getMethodPartName($nameMap, $concept)}($getterExpr, p);
 #elseif( ${Utilities.getClassName($type.componentType)} == $primitiveTypeClassName )
 ## Handle collection of primitives
 #set ( $tokenName = ${propertyToTokenNameMap.get($property)} )
 #set ( $typeString = $Utilities.getTypeName($type) )
-        for ($typeString $tokenName : $getterExpr) {
-            visitToken${Utilities.toUpperCaseIdent($tokenName)}($tokenName, p);
-        }
+            for ($typeString $tokenName : $getterExpr) {
+                visitToken${Utilities.toUpperCaseIdent($tokenName)}($tokenName, p);
+            }
 #end
 #elseif( $className == $primitiveTypeClassName )
 ## Handle primitive type
 #set ( $tokenName = ${propertyToTokenNameMap.get($property)} )
-        visitToken${Utilities.toUpperCaseIdent($tokenName)}($getterExpr, p);
+            visitToken${Utilities.toUpperCaseIdent($tokenName)}($getterExpr, p);
 #elseif( $className == $referenceTypeClassName )
-        if ($getterExpr != null && enterVisit($getterExpr)) {
-            visit${Utilities.getMethodPartName($nameMap, $type.concept)}($getterExpr, p);
-            exitVisit($getterExpr);
-        }
+            if ($getterExpr != null && enterVisit($getterExpr)) {
+                visit${Utilities.getMethodPartName($nameMap, $type.concept)}($getterExpr, p);
+                exitVisit($getterExpr);
+            }
 #else
             $Utilities.throwGeneratorException("Not known type for ${property.name}")
         // not known type for ${property.name}
@@ -71,9 +71,9 @@ public class ${className}<P> {
 #if( !$descendants.isEmpty() )
 #set( $ifToken = "if" )
 #foreach( $descendant in $descendants )
-        $ifToken (${Utilities.toLowerCaseIdent($concept.conceptName)} instanceof ${Utilities.getClassName($nameMap, $descendant)}) {
-            visit${Utilities.getMethodPartName($nameMap, $descendant)}((${Utilities.getClassName($nameMap, $descendant)}) ${Utilities.toLowerCaseIdent($concept.conceptName)}, p);
-        }
+            $ifToken (${Utilities.toLowerCaseIdent($concept.conceptName)} instanceof ${Utilities.getClassName($nameMap, $descendant)}) {
+                visit${Utilities.getMethodPartName($nameMap, $descendant)}((${Utilities.getClassName($nameMap, $descendant)}) ${Utilities.toLowerCaseIdent($concept.conceptName)}, p);
+            }
 #set( $ifToken = "else if" )
 #end
 #end

--- a/yajco-model/src/main/java/yajco/model/pattern/PatternSupport.java
+++ b/yajco-model/src/main/java/yajco/model/pattern/PatternSupport.java
@@ -1,15 +1,16 @@
 package yajco.model.pattern;
 
-import java.util.ArrayList;
-import java.util.List;
 import yajco.model.YajcoModelElement;
 
+import java.util.ArrayList;
+import java.util.List;
+
 public class PatternSupport<T extends Pattern> extends YajcoModelElement {
-    private List<T> patterns;
+    private final List<T> patterns;
 
     public PatternSupport(Object sourceElement) {
         super(sourceElement);
-        this.patterns = new ArrayList<T>();
+        this.patterns = new ArrayList<>();
     }
 
     public PatternSupport(List<T> patterns, Object sourceElement) {
@@ -25,12 +26,22 @@ public class PatternSupport<T extends Pattern> extends YajcoModelElement {
         patterns.add(pattern);
     }
 
-    //public T getPattern(Class<? extends Pattern> clazz) {
-    //public <R extends T> T getPattern(Class<R> clazz) {
-    public T getPattern(Class<? extends T> clazz) {
+    /**
+     * Get a pattern of <b>exactly</b> the given type from the patterns contained in this object.
+     * For example {@link yajco.model.Concept Concept} has {@link ConceptPattern ConceptPatterns} (type T)
+     * and you want to get an {@link yajco.model.pattern.impl.Operator Operator pattern} (type R - a subtype of
+     * ConceptPattern). The returned pattern is already cast to the requested type R.
+     *
+     * @param clazz class of the pattern you are searching
+     * @param <R>   Type of the pattern you are looking for.
+     *              It can be any subtype of {@link T} held in this object.
+     * @return searched pattern if present, otherwise null
+     */
+    public <R extends T> R getPattern(Class<R> clazz) {
         for (T pattern : patterns) {
             if (pattern.getClass().equals(clazz)) {
-                return pattern;
+                //noinspection unchecked
+                return (R) pattern;
             }
         }
 

--- a/yajco-model/src/main/java/yajco/model/pattern/PatternSupport.java
+++ b/yajco-model/src/main/java/yajco/model/pattern/PatternSupport.java
@@ -1,16 +1,15 @@
 package yajco.model.pattern;
 
-import yajco.model.YajcoModelElement;
-
 import java.util.ArrayList;
 import java.util.List;
+import yajco.model.YajcoModelElement;
 
 public class PatternSupport<T extends Pattern> extends YajcoModelElement {
-    private final List<T> patterns;
+    private List<T> patterns;
 
     public PatternSupport(Object sourceElement) {
         super(sourceElement);
-        this.patterns = new ArrayList<>();
+        this.patterns = new ArrayList<T>();
     }
 
     public PatternSupport(List<T> patterns, Object sourceElement) {
@@ -26,22 +25,12 @@ public class PatternSupport<T extends Pattern> extends YajcoModelElement {
         patterns.add(pattern);
     }
 
-    /**
-     * Get a pattern of <b>exactly</b> the given type from the patterns contained in this object.
-     * For example {@link yajco.model.Concept Concept} has {@link ConceptPattern ConceptPatterns} (type T)
-     * and you want to get an {@link yajco.model.pattern.impl.Operator Operator pattern} (type R - a subtype of
-     * ConceptPattern). The returned pattern is already cast to the requested type R.
-     *
-     * @param clazz class of the pattern you are searching
-     * @param <R>   Type of the pattern you are looking for.
-     *              It can be any subtype of {@link T} held in this object.
-     * @return searched pattern if present, otherwise null
-     */
-    public <R extends T> R getPattern(Class<R> clazz) {
+    //public T getPattern(Class<? extends Pattern> clazz) {
+    //public <R extends T> T getPattern(Class<R> clazz) {
+    public T getPattern(Class<? extends T> clazz) {
         for (T pattern : patterns) {
             if (pattern.getClass().equals(clazz)) {
-                //noinspection unchecked
-                return (R) pattern;
+                return pattern;
             }
         }
 

--- a/yajco-model/src/main/java/yajco/model/utilities/Utilities.java
+++ b/yajco-model/src/main/java/yajco/model/utilities/Utilities.java
@@ -1,12 +1,13 @@
 package yajco.model.utilities;
 
-import java.util.ArrayList;
-import java.util.Arrays;
-import java.util.HashMap;
-import java.util.List;
-import java.util.Map;
-
-import yajco.model.*;
+import yajco.model.Concept;
+import yajco.model.Language;
+import yajco.model.LocalVariablePart;
+import yajco.model.Notation;
+import yajco.model.NotationPart;
+import yajco.model.OptionalPart;
+import yajco.model.Property;
+import yajco.model.PropertyReferencePart;
 import yajco.model.pattern.NotationPartPattern;
 import yajco.model.pattern.Pattern;
 import yajco.model.pattern.PatternSupport;
@@ -17,6 +18,10 @@ import yajco.model.type.PrimitiveType;
 import yajco.model.type.PrimitiveTypeConst;
 import yajco.model.type.ReferenceType;
 import yajco.model.type.Type;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
 
 public class Utilities {
 
@@ -99,6 +104,14 @@ public class Utilities {
                 }
             } else {
                 throw new RuntimeException("Cannot find references.");
+            }
+        } else if (notationPart instanceof OptionalPart) {
+            for (NotationPart innerPart : ((OptionalPart) notationPart).getParts()) {
+                final Property property = getPropertyFromNotationPart(innerPart, concept);
+                // essentially we are skipping NotationParts without a corresponding Property (i.e. TokenParts)
+                if (property != null) {
+                    return property;
+                }
             }
         }
         return null;


### PR DESCRIPTION
- Fixes the issue when the generated `Printer` did not handle `Optional` types correctly. ~The PR introduces a similar fix to a9c2d99.~ Unwrap the optional property first.

- Does not enforce user anymore to have `Optional<?>` return type from the getter method of an optional property. Accomplished by using an overloaded method in the generated Visitor (and Printer), which return null when the optional is empty:
    - `T unwrapOptional(Optional<T> optional)`
    - `T unwrapOptional(T nonOptional)`
  - Now user can use either:
    - `Optional<Statement> getFalseBranch()` - returning `Optional.empty()` if missing
    - `Statement getFalseBranch()` - returning `null` if missing
    - `List<Declaration> getDeclarations()` - returning `null` if missing, it is **not** the same as an empty list

- Fixes printing tokens inside OptionalPart when it's empty (f.e. token from `@Before("else")` was printed even if the else branch was empty). Check if optional Notation part is empty before processing each of its inner parts.

- Fixes NPE in visitor methods by exiting immediately if parameter is null.