### PR TITLE
Missing separators in grammar

### DIFF
--- a/yajco-modules/yajco-grammar-module/src/main/java/yajco/grammar/translator/YajcoModelToBNFGrammarTranslator.java
+++ b/yajco-modules/yajco-grammar-module/src/main/java/yajco/grammar/translator/YajcoModelToBNFGrammarTranslator.java
@@ -548,7 +548,7 @@ public class YajcoModelToBNFGrammarTranslator {
             }
         } else {
             int symID = 1;
-            List<Symbol> symbols = new ArrayList<Symbol>(maxOccurs);
+            List<Symbol> symbols = new ArrayList<>(maxOccurs);
             for (int i = 0; i < minOccurs; i++) {
                 symbols.add(symbol instanceof NonterminalSymbol
                         ? new NonterminalSymbol(symbol.getName(), symbol.getReturnType(), DEFAULT_VAR_NAME + symID++)
@@ -556,9 +556,14 @@ public class YajcoModelToBNFGrammarTranslator {
                 );
             }
 
-            for (int i = minOccurs; i <= maxOccurs; i++) {
+            for (int occurrenceIndex = minOccurs; occurrenceIndex <= maxOccurs; occurrenceIndex++) {
                 Alternative alternative = new Alternative();
-                alternative.addSymbols(symbols);
+                for (int symbolIndex = 0; symbolIndex < symbols.size(); symbolIndex++) {
+                    if (sepTerminal != null && symbolIndex > 0) {
+                        alternative.addSymbol(sepTerminal);
+                    }
+                    alternative.addSymbol(symbols.get(symbolIndex));
+                }
                 alternative.addActions(unique
                         ? SemLangFactory.createOrderedSetAndAddElementsAndReturnActions(cmpType.getComponentType(), name, symbols)
                         : SemLangFactory.createListAndAddElementsAndReturnActions(cmpType.getComponentType(), name, symbols)

--- a/yajco-modules/yajco-grammar-module/src/main/java/yajco/grammar/translator/YajcoModelToBNFGrammarTranslator.java
+++ b/yajco-modules/yajco-grammar-module/src/main/java/yajco/grammar/translator/YajcoModelToBNFGrammarTranslator.java
@@ -515,9 +515,7 @@ public class YajcoModelToBNFGrammarTranslator {
             Alternative alternative3 = new Alternative();
 
             alternative1.addSymbol(rhsNonterminal);
-            if (sepTerminal != null) {
-                alternative1.addSymbol(sepTerminal);
-            }
+            alternative1.addSymbol(sepTerminal);
             alternative1.addSymbol(symbol);
             alternative1.addActions(SemLangFactory.createAddElementToCollectionAndReturnActions(rhsNonterminal, symbol));
 
@@ -559,7 +557,7 @@ public class YajcoModelToBNFGrammarTranslator {
             for (int occurrenceIndex = minOccurs; occurrenceIndex <= maxOccurs; occurrenceIndex++) {
                 Alternative alternative = new Alternative();
                 for (int symbolIndex = 0; symbolIndex < symbols.size(); symbolIndex++) {
-                    if (sepTerminal != null && symbolIndex > 0) {
+                    if (symbolIndex > 0) {
                         alternative.addSymbol(sepTerminal);
                     }
                     alternative.addSymbol(symbols.get(symbolIndex));


### PR DESCRIPTION
Grammar rules were totally missing terminal tokens of the selected separator between elements of the sequence. As a result, the scanner accepted sequences without a separator as if it was correct and gobbled any character between elements while reporting:
> Scanner Error:...: No token recognized at ...

This happpened when a sequence had finite `@Range.maxOccurs` and also a `@Separator`.

---
Example:
```java
public VariableDeclaration(@Before("VAR") @Range(minOccurs = 1, maxOccurs = 2) @Separator(",") Variable[] variables) { }
```
produced incorrectly:
```
VariableArray1
	= Variable.val1	{: ...
	| Variable.val1 Variable.val2	{: ...
```
now correctly produces:
```
VariableArray1
	= Variable.val1	{: ...
	| Variable.val1 SYMBOL_44 Variable.val2	{: ...
```