### PR TITLE
Fix exception thrown when hashCode() is overriden

### DIFF
--- a/yajco-annotations/src/main/java/yajco/ReferenceResolver.java
+++ b/yajco-annotations/src/main/java/yajco/ReferenceResolver.java
@@ -28,7 +28,7 @@ public class ReferenceResolver {
 
     private static final String USER_OBJECT_KEY = "object";
 
-    private Map<Object, Element> xmlElements = new HashMap<Object, Element>();
+    private final IdentityHashMap<Object, Element> xmlElements = new IdentityHashMap<>(85);
 
     /**
      * During the processing is the last node root. At the end root node will become the root node of XML document.

--- a/yajco-generator-tools/src/main/resources/yajco/generator/visitorgen/templates/Visitor.java.vm
+++ b/yajco-generator-tools/src/main/resources/yajco/generator/visitorgen/templates/Visitor.java.vm
@@ -8,13 +8,14 @@ import ${ModelUtilities.getFullConceptClassName($language, $concept)};
 #end
 import yajco.visitor.VisitorException;
 
-import java.util.HashSet;
+import java.util.Collections;
+import java.util.IdentityHashMap;
 import java.util.List;
 import java.util.Optional;
 import java.util.Set;
 
 public class ${className}<P> {
-    protected Set<Object> visited = new HashSet<Object>();
+    protected Set<Object> visited = Collections.newSetFromMap(new IdentityHashMap<>());
 
     public void visit(Object o, P p) {
 #set( $ifToken = "if" )

--- a/yajco-generator-tools/src/main/resources/yajco/generator/visitorgen/templates/Visitor.java.vm
+++ b/yajco-generator-tools/src/main/resources/yajco/generator/visitorgen/templates/Visitor.java.vm
@@ -15,7 +15,7 @@ import java.util.Optional;
 import java.util.Set;
 
 public class ${className}<P> {
-    protected Set<Object> visited = Collections.newSetFromMap(new IdentityHashMap<>());
+    protected Set<Object> visited = Collections.newSetFromMap(new IdentityHashMap<Object, Boolean>());
 
     public void visit(Object o, P p) {
 #set( $ifToken = "if" )


### PR DESCRIPTION
When the user defined concepts that overrode `hashCode()` dependent on a reference field, an exception was thrown, because elements got lost in the `xmlElements` map. It happened because:
1. object is put into map (hash code `X`)
2. object gets injected some `@References` field value (hash code changes to `XY`)
3. object is sought in the map but not found

A hash collision can also occur silently when ignoring the to-be-injected field in the `hashCode()` implementation and otherwise the hash code of similar objects match (f.e. `x := 7; x := 7`).

Using the reference field in `hashCode()` makes sense from the  perspective of the user because he considers the reference field final after being injected. The reference field is often crucial when implementing structural equality. `ReferenceResolver` cannot rely on the `equals()` and `hashCode()` implementation provided by the user, that's why it is needed to swap the `Map` implementation from `HashMap` to `IdentityHashMap`.

According to the JavaDoc (emphasis mine), the `IdentityHashMap` is **exactly** what `ReferenceResolver` needs:
> [IdentityHashMap](https://docs.oracle.com/en/java/javase/11/docs/api/java.base/java/util/IdentityHashMap.html) is not a general-purpose Map implementation! ...
A typical use of this class is _topology-preserving object graph transformations_, such as serialization or deep-copying. To perform such a transformation, a program must maintain a "node table" that **keeps track of all the object references that have already been processed. The node table must not equate distinct objects even if they happen to be equal.**

### How to reproduce
```java
public class VariableUsage implements Expression {
	private Variable var;

	public VariableUsage(@References(value = Variable.class, field = "var") String name) {
	}

	public Variable getVar() {
		return var;
	}

	protected void setVar(Variable var) {
		this.var = var;
	}

	@Override
	public boolean equals(Object o) {
		if (this == o) return true;
		if (!(o instanceof VariableUsage)) return false;

		final VariableUsage that = (VariableUsage) o;

		return Objects.equals(var, that.var);
	}

	@Override
	public int hashCode() {
		return 1807526874 + Objects.hash(var);
	}
}
```
NB: Method `setVar()` can be deleted and the `var` field could even be `final` when the user relies on ReferenceResolver setting the field reflectively.