### PR TITLE
A common interface for all parsers

### DIFF
--- a/yajco-modules/yajco-antlr4-parser-generator-module/src/main/java/yajco/generator/parsergen/antlr4/Antlr4CompilerGenerator.java
+++ b/yajco-modules/yajco-antlr4-parser-generator-module/src/main/java/yajco/generator/parsergen/antlr4/Antlr4CompilerGenerator.java
@@ -131,6 +131,7 @@ public class Antlr4CompilerGenerator implements CompilerGenerator {
                     yajco.model.utilities.Utilities.getFullConceptClassName(language, language.getConcepts().get(0))
                 ));
             }
+            CompilerGenerator.registerParserServiceProvider(parserFullClassName, filer);
 
             // Create parse exception
             try (Writer writer = filer.createSourceFile(parserPackageName + ".ParseException").openWriter()) {

--- a/yajco-modules/yajco-antlr4-parser-generator-module/src/main/resources/yajco/generator/parsergen/antlr4/templates/ParseException.java.vm
+++ b/yajco-modules/yajco-antlr4-parser-generator-module/src/main/resources/yajco/generator/parsergen/antlr4/templates/ParseException.java.vm
@@ -1,6 +1,6 @@
 package $parserPackageName;
 
-public class ParseException extends Exception {
+public class ParseException extends yajco.generator.parsergen.ParseException {
     public ParseException(String message, Throwable cause) {
         super(message, cause);
     }

--- a/yajco-modules/yajco-antlr4-parser-generator-module/src/main/resources/yajco/generator/parsergen/antlr4/templates/Parser.java.vm
+++ b/yajco-modules/yajco-antlr4-parser-generator-module/src/main/resources/yajco/generator/parsergen/antlr4/templates/Parser.java.vm
@@ -6,7 +6,8 @@ import org.antlr.v4.runtime.CommonTokenStream;
 import org.antlr.v4.runtime.BailErrorStrategy;
 import org.antlr.v4.runtime.misc.ParseCancellationException;
 
-public class $parserClassName {
+public class $parserClassName implements yajco.generator.parsergen.Parser<$mainElementClassName, ParseException> {
+    @Override
     public $mainElementClassName parse(String input) throws ParseException {
         TokenSource lexer = new ${ANTLRLexerFullClassName}(CharStreams.fromString(input));
         ${ANTLRParserFullClassName} parser = new ${ANTLRParserFullClassName}(new CommonTokenStream(lexer));
@@ -22,6 +23,7 @@ public class $parserClassName {
         }
     }
 
+    @Override
     public $mainElementClassName parse(java.io.Reader reader) throws ParseException {
         try {
             return parse(readAsString(reader));

--- a/yajco-modules/yajco-beaver-parser-generator-module/src/main/java/yajco/generator/parsergen/BeaverCompilerGenerator.java
+++ b/yajco-modules/yajco-beaver-parser-generator-module/src/main/java/yajco/generator/parsergen/BeaverCompilerGenerator.java
@@ -112,11 +112,13 @@ public class BeaverCompilerGenerator implements CompilerGenerator {
 
         // hlavna trieda parsera
         //file = Utilities.createFile(filer, parserClassPackageName, parserClassName + ".java");
-        fileObject = filer.createSourceFile(parserClassPackageName + "." + parserClassName);
+        final String mainParserFQN = parserClassPackageName + "." + parserClassName;
+        fileObject = filer.createSourceFile(mainParserFQN);
         writer = fileObject.openWriter(); //new FileWriter(file);
         writer.write(generateBeaverParserClass(parserClassName, parserPackageName, parserClassPackageName, mainElementClassName, scannerClassName, ReferenceResolver.class.getCanonicalName()));
         writer.flush();
         writer.close();
+        CompilerGenerator.registerParserServiceProvider(mainParserFQN, filer);
 
         // trieda vynimky parsera
         //file = Utilities.createFile(filer, parserClassPackageName, "LALRParseException.java");

--- a/yajco-modules/yajco-beaver-parser-generator-module/src/main/resources/yajco/generator/parsergen/beaver/templates/LALRParseExceptionClassTemplate.vm
+++ b/yajco-modules/yajco-beaver-parser-generator-module/src/main/resources/yajco/generator/parsergen/beaver/templates/LALRParseExceptionClassTemplate.vm
@@ -2,7 +2,7 @@
 ##Input - parserClassPackageName
 package $parserClassPackageName;
 
-public class ParseException extends Exception {
+public class ParseException extends yajco.generator.parsergen.ParseException {
 	public ParseException(String message, Throwable cause) {
 		super(message, cause);
 	}

--- a/yajco-modules/yajco-beaver-parser-generator-module/src/main/resources/yajco/generator/parsergen/beaver/templates/LALRParserClassMetaLexerTemplate.vm
+++ b/yajco-modules/yajco-beaver-parser-generator-module/src/main/resources/yajco/generator/parsergen/beaver/templates/LALRParserClassMetaLexerTemplate.vm
@@ -10,13 +10,15 @@ package $parserClassPackageName;
 import java.io.StringReader;
 import ${parserPackageName}.$scannerClassName;
 
-public class $parserClassName {
+public class $parserClassName implements yajco.generator.parsergen.Parser<$mainElementClassName, LALRParseException> {
 	private static ${parserPackageName}.$parserClassName parser;
 
+	@Override
 	public $mainElementClassName parse(String input) throws LALRParseException {
 		return parse(new StringReader(input));
 	}
 
+	@Override
 	public $mainElementClassName parse(java.io.Reader reader) throws LALRParseException {
 		$scannerClassName scanner = new ${scannerClassName}(reader);
 		if (parser == null) {

--- a/yajco-modules/yajco-beaver-parser-generator-module/src/main/resources/yajco/generator/parsergen/beaver/templates/LALRParserClassTemplate.vm
+++ b/yajco-modules/yajco-beaver-parser-generator-module/src/main/resources/yajco/generator/parsergen/beaver/templates/LALRParserClassTemplate.vm
@@ -9,9 +9,10 @@ package $parserClassPackageName;
 
 import ${parserPackageName}.$scannerClassName;
 
-public class $parserClassName {
+public class $parserClassName implements yajco.generator.parsergen.Parser<$mainElementClassName, ParseException> {
 	private static ${parserPackageName}.$parserClassName parser;
 
+	@Override
 	public $mainElementClassName parse(String input) throws ParseException {
 		$scannerClassName scanner = new ${scannerClassName}(input);
 		if (parser == null) {
@@ -30,6 +31,7 @@ public class $parserClassName {
 		}
 	}
 
+	@Override
 	public $mainElementClassName parse(java.io.Reader reader) throws ParseException {
 		try {
 			return parse(readAsString(reader));

--- a/yajco-modules/yajco-generator-module/src/main/java/yajco/generator/parsergen/CompilerGenerator.java
+++ b/yajco-modules/yajco-generator-module/src/main/java/yajco/generator/parsergen/CompilerGenerator.java
@@ -1,13 +1,35 @@
 package yajco.generator.parsergen;
 
-import java.io.File;
-import java.util.Properties;
-import javax.annotation.processing.Filer;
 import yajco.generator.FilesGenerator;
 import yajco.model.Language;
 
-public interface CompilerGenerator extends FilesGenerator{
+import javax.annotation.processing.Filer;
+import javax.tools.FileObject;
+import javax.tools.StandardLocation;
+import java.io.IOException;
+import java.io.OutputStreamWriter;
+import java.util.Properties;
 
-    void generateFiles(Language language, Filer filer, Properties properties, String parserClassName);
-    
+import static java.nio.charset.StandardCharsets.UTF_8;
+
+public interface CompilerGenerator extends FilesGenerator {
+
+	/**
+	 * Registers the given class as the service provider of the {@link Parser} service as per the SPI contract.
+	 *
+	 * @param parserFQN fully qualified name of the class implementing {@link Parser}
+	 * @param filer     filer used to
+	 * @throws IOException if the file cannot be created or an I/O error occurs
+	 * @see java.util.ServiceLoader
+	 */
+	static void registerParserServiceProvider(String parserFQN, Filer filer) throws IOException {
+		FileObject fo = filer.createResource(StandardLocation.CLASS_OUTPUT, "" ,
+				"META-INF/services/" + Parser.class.getName());
+		try (OutputStreamWriter out = new OutputStreamWriter(fo.openOutputStream(), UTF_8)) {
+			out.write(parserFQN);
+		}
+	}
+
+	void generateFiles(Language language, Filer filer, Properties properties, String parserClassName);
+
 }

--- a/yajco-modules/yajco-generator-module/src/main/java/yajco/generator/parsergen/ParseException.java
+++ b/yajco-modules/yajco-generator-module/src/main/java/yajco/generator/parsergen/ParseException.java
@@ -1,0 +1,7 @@
+package yajco.generator.parsergen;
+
+public class ParseException extends Exception {
+	public ParseException(String message, Throwable cause) {
+		super(message, cause);
+	}
+}

--- a/yajco-modules/yajco-generator-module/src/main/java/yajco/generator/parsergen/Parser.java
+++ b/yajco-modules/yajco-generator-module/src/main/java/yajco/generator/parsergen/Parser.java
@@ -2,7 +2,15 @@ package yajco.generator.parsergen;
 
 import java.io.Reader;
 
+/**
+ * Is a service as per the SPI contract.
+ *
+ * @param <T> type of the main (root) node in the parsed AST (sentence)
+ * @param <E> specific parser exception
+ * @see java.util.ServiceLoader
+ */
 public interface Parser<T, E extends Exception> {
 	T parse(String input) throws E;
+
 	T parse(Reader reader) throws E;
 }

--- a/yajco-modules/yajco-generator-module/src/main/java/yajco/generator/parsergen/Parser.java
+++ b/yajco-modules/yajco-generator-module/src/main/java/yajco/generator/parsergen/Parser.java
@@ -9,7 +9,7 @@ import java.io.Reader;
  * @param <E> specific parser exception
  * @see java.util.ServiceLoader
  */
-public interface Parser<T, E extends Exception> {
+public interface Parser<T, E extends ParseException> {
 	T parse(String input) throws E;
 
 	T parse(Reader reader) throws E;

--- a/yajco-modules/yajco-generator-module/src/main/java/yajco/generator/parsergen/Parser.java
+++ b/yajco-modules/yajco-generator-module/src/main/java/yajco/generator/parsergen/Parser.java
@@ -1,0 +1,8 @@
+package yajco.generator.parsergen;
+
+import java.io.Reader;
+
+public interface Parser<T, E extends Exception> {
+	T parse(String input) throws E;
+	T parse(Reader reader) throws E;
+}

--- a/yajco-modules/yajco-javacc-parser-generator-module/src/main/java/yajco/generator/parsergen/javacc/JavaCCParserGenerator.java
+++ b/yajco-modules/yajco-javacc-parser-generator-module/src/main/java/yajco/generator/parsergen/javacc/JavaCCParserGenerator.java
@@ -15,6 +15,7 @@ import org.apache.velocity.app.VelocityEngine;
 import org.javacc.parser.Main;
 import yajco.annotation.config.Option;
 import yajco.generator.GeneratorException;
+import yajco.generator.parsergen.CompilerGenerator;
 import yajco.generator.parsergen.Conversions;
 import yajco.generator.parsergen.javacc.model.Choice;
 import yajco.generator.parsergen.javacc.model.Expansion;
@@ -147,11 +148,13 @@ public class JavaCCParserGenerator {
 
             //generate parser class
             //file = Utilities.createFile(filer, parserMainParserPackageName, parserClassName + ".java");
-            fileObject = filer.createSourceFile(parserMainParserPackageName + "." + parserClassName);
+            final String mainParserFQN = parserMainParserPackageName + "." + parserClassName;
+            fileObject = filer.createSourceFile(mainParserFQN);
             writer = fileObject.openWriter(); //new FileWriter(file);
             writer.write(generateParserClass(parserClassName, parserMainParserPackageName, parserJavaCCPackageName, language.getName() + "." + language.getConcepts().get(0).getName()));
             writer.flush();
             writer.close();
+            CompilerGenerator.registerParserServiceProvider(mainParserFQN, filer);
 
             // register later generated files for compilation
             String[] laterGenFiles = {

--- a/yajco-modules/yajco-javacc-parser-generator-module/src/main/resources/yajco/generator/parsergen/javacc/templates/Parser.javavm
+++ b/yajco-modules/yajco-javacc-parser-generator-module/src/main/resources/yajco/generator/parsergen/javacc/templates/Parser.javavm
@@ -2,9 +2,10 @@
 #set( $tokenManagerClassName = $parserJavaCCPackageName + "." + $parserClassName + "TokenManager")
 package $parserPackageName;
 
-public class $parserClassName {
+public class $parserClassName implements yajco.generator.parsergen.Parser<$mainElementName, ParseException> {
   private static $parserJavaCCClassName _parser;
 
+  @Override
   public $mainElementName parse(String input) throws ParseException {
     $tokenManagerClassName tm = new $tokenManagerClassName(input);
     if (_parser == null) {
@@ -23,6 +24,7 @@ public class $parserClassName {
     }
   }
 
+  @Override
   public $mainElementName parse(java.io.Reader reader) throws ParseException {
     try {
       return parse(readAsString(reader));

--- a/yajco-modules/yajco-javacc-parser-generator-module/src/main/resources/yajco/generator/parsergen/javacc/templates/ParserException.javavm
+++ b/yajco-modules/yajco-javacc-parser-generator-module/src/main/resources/yajco/generator/parsergen/javacc/templates/ParserException.javavm
@@ -1,6 +1,6 @@
 package $parserPackageName;
 
-public class ParseException extends Exception {
+public class ParseException extends yajco.generator.parsergen.ParseException {
   public ParseException(String message, Throwable cause) {
     super(message, cause);
   }

--- a/yajco-parser/src/main/java/yajco/parser/LALRParseException.java
+++ b/yajco-parser/src/main/java/yajco/parser/LALRParseException.java
@@ -1,6 +1,6 @@
 package yajco.parser;
 
-public class LALRParseException extends Exception {
+public class LALRParseException extends yajco.generator.parsergen.ParseException {
 	public LALRParseException(String message, Throwable cause) {
 		super(message, cause);
 	}

--- a/yajco-parser/src/main/java/yajco/parser/YajcoParser.java
+++ b/yajco-parser/src/main/java/yajco/parser/YajcoParser.java
@@ -2,9 +2,10 @@ package yajco.parser;
 
 import yajco.parser.beaver.YajcoParserScanner;
 
-public class YajcoParser {
+public class YajcoParser implements yajco.generator.parsergen.Parser<yajco.model.Language, LALRParseException> {
 	private static yajco.parser.beaver.YajcoParser parser;
 
+	@Override
 	public yajco.model.Language parse(String input) throws LALRParseException {
 		YajcoParserScanner scanner = new YajcoParserScanner(input);
 		if (parser == null) {
@@ -23,6 +24,7 @@ public class YajcoParser {
 		}
 	}
 
+	@Override
 	public yajco.model.Language parse(java.io.Reader reader) throws LALRParseException {
 		try {
 			return parse(readAsString(reader));

--- a/yajco-prototype-modules/yajco-lisa-parser-generator-module/src/main/java/yajco/generator/parsergen/lisa/LisaCompilerGenerator.java
+++ b/yajco-prototype-modules/yajco-lisa-parser-generator-module/src/main/java/yajco/generator/parsergen/lisa/LisaCompilerGenerator.java
@@ -142,11 +142,13 @@ public class LisaCompilerGenerator implements CompilerGenerator {
             //---- LISA YAJCO COMPILER ----
             String parserClassPackageName = parserPackageName.substring(0, parserPackageName.lastIndexOf('.'));
             //file = Utilities.createFile(filer, parserClassPackageName, LISA_PARSER_CLASS_NAME + ".java");
-            fileObject = filer.createClassFile(parserClassPackageName+"."+LISA_PARSER_CLASS_NAME);
+            final String lisaCompilerFQN = parserClassPackageName + "." + LISA_PARSER_CLASS_NAME;
+            fileObject = filer.createClassFile(lisaCompilerFQN);
             writer = fileObject.openWriter(); //new FileWriter(file);
             //writer.write(getLisaCompiler(language));
             writer.write(generateLisaCompilerClass(LISA_PARSER_CLASS_NAME, parserPackageName, parserClassPackageName, mainElementClassName, LISA_SCANNER_CLASS_NAME, LISA_TRANSLATOR_CLASS_NAME, ReferenceResolver.class.getCanonicalName()));
             writer.close();
+            CompilerGenerator.registerParserServiceProvider(lisaCompilerFQN, filer);
 
             //----- LISA EXCEPTION CLASS ----
             //file = Utilities.createFile(filer, parserClassPackageName, "LisaParseException.java");

--- a/yajco-prototype-modules/yajco-lisa-parser-generator-module/src/main/resources/yajco/generator/parsergen/lisa/templates/ParseExceptionClassTemplate.vm
+++ b/yajco-prototype-modules/yajco-lisa-parser-generator-module/src/main/resources/yajco/generator/parsergen/lisa/templates/ParseExceptionClassTemplate.vm
@@ -1,7 +1,7 @@
 ##Input - parserClassPackageName
 package $parserClassPackageName;
 
-public class LisaParseException extends Exception {
+public class LisaParseException extends yajco.generator.parsergen.ParseException {
 	public LisaParseException(String message, Throwable cause) {
 		super(message, cause);
 	}

--- a/yajco-prototype-modules/yajco-lisa-parser-generator-module/src/main/resources/yajco/generator/parsergen/lisa/templates/ParserClassTemplate.vm
+++ b/yajco-prototype-modules/yajco-lisa-parser-generator-module/src/main/resources/yajco/generator/parsergen/lisa/templates/ParserClassTemplate.vm
@@ -7,9 +7,10 @@
 ## Input - translatorClassName
 package $parserClassPackageName;
 
-public class $parserClassName {
+public class $parserClassName implements yajco.generator.parsergen.Parser<$mainElementClassName, LisaParseException> {
 	private static ${parserPackageName}.$parserClassName parser;
 
+	@Override
 	public $mainElementClassName parse(String input) throws LisaParseException {
 		java.io.ByteArrayInputStream is = new java.io.ByteArrayInputStream(input.getBytes());
 		try {
@@ -30,6 +31,7 @@ public class $parserClassName {
                 return null;
 	}
 
+	@Override
 	public $mainElementClassName parse(java.io.Reader reader) throws LisaParseException {
 		try {
 			return parse(readAsString(reader));


### PR DESCRIPTION
This PR makes all generated parsers implement this interface:
```java
package yajco.generator.parsergen;

public interface Parser<T, E extends Exception> {
	T parse(String input) throws E;
	T parse(Reader reader) throws E;
}
```
**Optional:** Make a common superclass ParseException for all thrown exceptions in all parsers (`LisaParseException` , `ParseException`, `LALRParseException`), so the generic parameter can be more specific `E extends ParseException`.


### Use case
A common interface can help to work with the generated parser dynamically. I load the generated class dynamically so I cannot cast it to its static type. With an interface in the `yajco-generator-module` I can cast it to `Parser`, so that I don't need to use reflection.

### Is it a good idea?
I am not sure if it is desired to introduce a dependency on `yajco-generator-module` into the generated files, because also classes like `ParseException`, `SymbolWrapper`, ... are generated and not imported from YAJCo. But what is the benefit of not having a dependency? There is already an import of `yajco.lexer.*` from `yajco-annotations` module.
The modules `yajco-annotation-processor` and all of the `yajco-*-generator-module` already have a dependency on `yajco-generator-module`, which means this is not a new dependency for the user, the user _must_ already have a transitive dependency on `yajco-generator-module`.