### PR TITLE
Recognize @Identifier defined in base class #32

### DIFF
--- a/yajco-annotations/src/main/java/yajco/ReferenceResolver.java
+++ b/yajco-annotations/src/main/java/yajco/ReferenceResolver.java
@@ -46,12 +46,12 @@ public class ReferenceResolver {
     private XPath xpath;
 
     /** Map from class to field with Identifier annotation. */
-    private Map<Class, Field> identifierFields = new HashMap<Class, Field>();
+    private final Map<Class<?>, Field> identifierFields = new HashMap<>();
 
     /** List of already processed classes without Identifier  annotation.
      * Created just for performance reasons for faster resolving of identifiers fields.
      */
-    private Set<Class> classesWithoutIdentifiers = new HashSet<Class>();
+    private final Set<Class<?>> classesWithoutIdentifiers = new HashSet<>();
 
     /** List of nodes requiring reference. */
     private List<ReferenceItem> nodesToResolve = new ArrayList<ReferenceItem>();
@@ -427,11 +427,30 @@ public class ReferenceResolver {
         throw new RuntimeException("Referencing field of type '" + type + "' not found in class '" + clazz + "'");
     }
 
-    private Field getIdentifierField(Class clazz) {
+    private <T> Field getIdentifierField(Class<T> clazz) {
+        return getIdentifierField(clazz, clazz);
+    }
+
+    /**
+     * You should call {@link #getIdentifierField(Class)} to start this search (with {@code clazz == requester}).
+     * <p>
+     * Search for the field annotated with {@link Identifier} in {@code clazz} and recursively in its parents (up to Object).
+     * All of the classes including and between requester and clazz will be cached in {@link #identifierFields}.
+     *
+     * @param clazz     the current class to check for the identifier field
+     * @param requester the original subclass whose identifier field we are searching
+     * @param <T>       type of the class this recursive search started with
+     * @return identifier field of requester (declared in {@code requester} or one of its superclasses),
+     * or null if requester does not have an identifier field
+     */
+    private <T> Field getIdentifierField(Class<? super T> clazz, Class<T> requester) {
+        if (clazz == null) { // == Object.class.getSuperclass()
+            return null;
+        }
         {
             Field field = identifierFields.get(clazz);
             if (field != null) {
-                return field;
+                return cacheIdentifierField(field, requester, clazz);
             }
             if (classesWithoutIdentifiers.contains(clazz)) {
                 return null;
@@ -440,13 +459,23 @@ public class ReferenceResolver {
 
         for (Field field : clazz.getDeclaredFields()) {
             if (field.getAnnotation(Identifier.class) != null) {
-                identifierFields.put(clazz, field);
-                return field;
+                return cacheIdentifierField(field, requester, clazz);
             }
         }
 
         classesWithoutIdentifiers.add(clazz);
-        return null;
+        return getIdentifierField(clazz.getSuperclass(), requester);
+    }
+
+    /**
+     * @return input field
+     */
+    private <T> Field cacheIdentifierField(Field field, Class<T> from, Class<? super T> to) {
+        // from <= clsToCache <= to
+        for (Class<? super T> clsToCache = from; clsToCache != null && to.isAssignableFrom(clsToCache); clsToCache = clsToCache.getSuperclass()) {
+            identifierFields.put(clsToCache, field);
+        }
+        return field;
     }
 
     //TODO: potom upravit nielen priamo na triedu ale aj predkov

--- a/yajco-generator-tools/src/main/resources/yajco/generator/printergen/templates/Printer.java.vm
+++ b/yajco-generator-tools/src/main/resources/yajco/generator/printergen/templates/Printer.java.vm
@@ -371,7 +371,7 @@ public class $className extends ${visitorClassName}<PrintWriter> {
     #elseif( $className == $referenceTypeClassName )
      #if( $notationPartClassName == $localVariablePartClassName )
       ## je potrebne vypisat len hodnotu z Identifier property, kedze je to referencovane len menom v originali
-      #set( $propertyWithIdentifier = ${ModelUtilities.getIdentifierProperty(${type.concept})} )
+      #set( $propertyWithIdentifier = ${ModelUtilities.getIdentifierProperty(${type.concept}).property} )
         printLiteral(${getterExpr}.get${Utilities.toUpperCaseIdent(${propertyWithIdentifier.name})}(), p);
      #else
 ##      #set( $hasLocalParenthesesPattern = ${Utilities.hasClassInList(${$type.concept.patterns},${parenthesesPatternClassName})} )

--- a/yajco-model/src/main/java/yajco/model/utilities/PropertyInConcept.java
+++ b/yajco-model/src/main/java/yajco/model/utilities/PropertyInConcept.java
@@ -1,0 +1,78 @@
+package yajco.model.utilities;
+
+import yajco.model.Concept;
+import yajco.model.Property;
+import yajco.model.type.Type;
+
+import java.io.Serializable;
+import java.util.Objects;
+
+/**
+ * A {@link Property} which is possible to be checked for equality with another property,
+ * even though they need not be identical (p1 == p2). Useful as a HashMap key.
+ */
+public class PropertyInConcept implements Serializable {
+    private static final long     serialVersionUID = 4378498045837368587L;
+    private final        Property property;
+    private final        Concept  concept;
+
+    /**
+     * @param property property to wrap
+     * @param concept  concept in which property is defined
+     * @throws NullPointerException     if property or concept is null
+     * @throws IllegalArgumentException if property is not defined directly in concept
+     */
+    public PropertyInConcept(Property property, Concept concept) {
+        this.property = Objects.requireNonNull(property);
+        this.concept = Objects.requireNonNull(concept);
+        if (!concept.getAbstractSyntax().contains(property)) {
+            throw new IllegalArgumentException("Property " + property.getName() + " is not defined in " + concept.getName());
+        }
+    }
+
+    public Property getProperty() {
+        return property;
+    }
+
+    public Concept getConcept() {
+        return concept;
+    }
+
+    /**
+     * <ol>These must be equal:
+     *  <li>{@link Concept}</li>
+     *  <li>{@link Property#getName()}</li>
+     *  <li>class of {@link Property#getType()}</li>
+     * </ol>
+     */
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (!(o instanceof PropertyInConcept)) return false;
+
+        final PropertyInConcept that = (PropertyInConcept) o;
+
+        if (!Objects.equals(concept, that.concept)) return false;
+        if (!Objects.equals(property.getName(), that.property.getName())) return false;
+
+        final Type type = property.getType();
+        final Type thatType = that.property.getType();
+        if (type == null || thatType == null) {
+            return type == thatType;
+        }
+        return Objects.equals(type.getClass(), thatType.getClass());
+    }
+
+    /**
+     * <ol>Depends on:
+     *  <li>{@link Concept}</li>
+     *  <li>{@link Property#getName()}</li>
+     *  <li>class of {@link Property#getType()}</li>
+     * </ol>
+     */
+    @Override
+    public int hashCode() {
+        final Type type = property.getType();
+        return Objects.hash(-455370592, concept, property.getName(), (type == null) ? 0 : type.getClass());
+    }
+}

--- a/yajco-model/src/main/java/yajco/model/utilities/Utilities.java
+++ b/yajco-model/src/main/java/yajco/model/utilities/Utilities.java
@@ -161,13 +161,24 @@ public class Utilities {
         return false;
     }
 
-    public static Property getIdentifierProperty(Concept concept) {
+    /**
+     * Search for the property with the {@link Identifier} pattern in {@code concept} and recursively in its parents.
+     *
+     * @param concept the concept whose identifier property we are searching
+     * @return identifier property of {@code concept} (declared in {@code concept} or one of its super-concepts),
+     * or null if concept does not have an identifier field
+     */
+    public static PropertyInConcept getIdentifierProperty(Concept concept) {
+        if (concept == null) {
+            return null;
+        }
+
         for (Property property : concept.getAbstractSyntax()) {
             if (property.getPattern(Identifier.class) != null) {
-                return property;
+                return new PropertyInConcept(property, concept);
             }
         }
-        return null;
+        return getIdentifierProperty(concept.getParent());
     }
 
     public static String toUpperCaseNotation(String camelNotation) {


### PR DESCRIPTION
Fixes kpi-tuke/yajco#32

find identifier fields also from parents recursively
- in ReferenceResolver
  - caches all subclasses when found
- in Utilities
  - updated usage in Printer
- adds new class wrapping Property and its owner Concept (extension by composition)
  - implemented equals & hashcode => good for hashmap keys & serialization
- all well documented