### PR TITLE
Fix grammar: Optional rule has a sequence instead of value

### DIFF
--- a/yajco-modules/yajco-grammar-module/src/main/java/yajco/grammar/translator/YajcoModelToBNFGrammarTranslator.java
+++ b/yajco-modules/yajco-grammar-module/src/main/java/yajco/grammar/translator/YajcoModelToBNFGrammarTranslator.java
@@ -410,12 +410,12 @@ public class YajcoModelToBNFGrammarTranslator {
     }
 
     private Symbol translateComponentTypePropertyRef(PropertyReferencePart part) {
-        ComponentType cmpType = (ComponentType) part.getProperty().getType();
-        Type innerType = cmpType.getComponentType();
-        Symbol symbol;
-        String separator, sharedPartName;
-        int min, max;
-        boolean unique;
+        final ComponentType cmpType = (ComponentType) part.getProperty().getType();
+        final Type innerType = cmpType.getComponentType();
+        final Symbol symbol;
+        final String separator, sharedPartName;
+        final int min, max;
+        final boolean unique;
 
         if (innerType instanceof ReferenceType) {
             ReferenceType refType = (ReferenceType) innerType;
@@ -442,26 +442,18 @@ public class YajcoModelToBNFGrammarTranslator {
         min = rangePattern != null ? rangePattern.getMinOccurs() : 0;
         max = rangePattern != null ? rangePattern.getMaxOccurs() : Range.INFINITY;
 
-        NonterminalSymbol nonterminal = grammar.getSequenceNonterminalFor(symbol.toString(), min, max, separator, unique, sharedPartName);
-        if (nonterminal != null) {
-            return new NonterminalSymbol(nonterminal.getName(), cmpType, nonterminal.getVarName());
-        } else {
-            if (cmpType instanceof OptionalType) {
-                return symbol;
-            } else if (sharedPattern != null) {
-                return createSequenceProductionWithSharedFor(symbol, min, max, separator, cmpType, sharedPattern);
-            } else {
-                return createSequenceProductionFor(symbol, min, max, separator, cmpType, unique);
-            }
+        if (cmpType instanceof OptionalType) {
+            return symbol;
         }
+        return getOrCreateSequenceProductionFor(symbol, min, max, separator, cmpType, unique, sharedPattern, sharedPartName);
     }
 
     private NonterminalSymbol translateOptionalComponentTypePropertyRef(ComponentType cmpType, PropertyReferencePart part) {
-        Type innerType = cmpType.getComponentType();
-        Symbol symbol;
-        String separator, sharedPartName;
-        int min, max;
-        boolean unique;
+        final Type innerType = cmpType.getComponentType();
+        final Symbol symbol;
+        final String separator, sharedPartName;
+        final int min, max;
+        final boolean unique;
 
         if (innerType instanceof ReferenceType) {
             ReferenceType refType = (ReferenceType) innerType;
@@ -485,15 +477,18 @@ public class YajcoModelToBNFGrammarTranslator {
         min = rangePattern != null ? rangePattern.getMinOccurs() : 1;
         max = rangePattern != null ? rangePattern.getMaxOccurs() : Range.INFINITY;
 
-        NonterminalSymbol nonterminal = grammar.getSequenceNonterminalFor(symbol.toString(), min, max, separator, unique, sharedPartName);
+        return getOrCreateSequenceProductionFor(symbol, min, max, separator, cmpType, unique, sharedPattern, sharedPartName);
+    }
+
+    private NonterminalSymbol getOrCreateSequenceProductionFor(Symbol symbol, int minOccurs, int maxOccurs, String separator, ComponentType cmpType, boolean unique, Shared sharedPattern, String sharedPartName) {
+        NonterminalSymbol nonterminal = grammar.getSequenceNonterminalFor(symbol.toString(), minOccurs, maxOccurs, separator, unique, sharedPartName);
         if (nonterminal != null) {
             return new NonterminalSymbol(nonterminal.getName(), cmpType, nonterminal.getVarName());
+        }
+        if (sharedPattern != null) {
+            return createSequenceProductionWithSharedFor(symbol, minOccurs, maxOccurs, separator, cmpType, sharedPattern);
         } else {
-            if (sharedPattern != null) {
-                return createSequenceProductionWithSharedFor(symbol, min, max, separator, cmpType, sharedPattern);
-            } else {
-                return createSequenceProductionFor(symbol, min, max, separator, cmpType, unique);
-            }
+            return createSequenceProductionFor(symbol, minOccurs, maxOccurs, separator, cmpType, unique);
         }
     }
 


### PR DESCRIPTION
# Problem

If the `Statement` in an `Optional<Statement>` constructor parameter happens to be used as a sequence (`List<Statement>`, `Statement[]`) somewhere else, the grammar incorrectly produces this:
```
OptionalStatement_1
    = ELSE StatementArray1.falseStatement   
    |   
    ;
```
instead of this:
```
OptionalStatement_1
    = ELSE Statement.falseStatement   
    |   
    ;
```

# How to reproduce

```java
public class Block implements Statement {
    @Before("LBR") @After("RBR")
    public Block(Statement[] statements) { /* ... */ }
}

public class Condition implements Statement {
    public Condition(
            @Before({"IF", "LPAR"}) @After("RPAR") Expression expression, 
            Statement trueStatement, 
            @Before("ELSE") Optional<Statement> falseStatement) { /* ... */ }
}
```
Precondition: `Block`'s `statements` must be processed before the `elseStatement` for the bug to occur.

# Changelog
fix `translateComponentTypePropertyRef()` incorrectly wrapping the resulting symbol into a sequence when creating an optional rule
- resolve OptionalType before creating sequence
- extract duplicate code for general sequence production creation
- mark local variables final just to use a more careful style