### PR TITLE
Annotation processor refactoring

### DIFF
--- a/yajco-annotation-processor/src/main/java/yajco/annotation/processor/AnnotationProcessor.java
+++ b/yajco-annotation-processor/src/main/java/yajco/annotation/processor/AnnotationProcessor.java
@@ -143,8 +143,7 @@ public class AnnotationProcessor extends AbstractProcessor {
      */
     private Properties loadSettingsFromSettingsFile() {
         Properties loadedProperties = new Properties();
-        try {
-            InputStream inputStream = getClass().getResourceAsStream(PROPERTY_SETTINGS_FILE);
+        try (InputStream inputStream = getClass().getResourceAsStream(PROPERTY_SETTINGS_FILE)) {
             loadedProperties.load(inputStream);
             logger.debug("Loaded config from file: {}", loadedProperties);
         } catch (Exception e) {

--- a/yajco-annotation-processor/src/main/java/yajco/annotation/processor/AnnotationProcessor.java
+++ b/yajco-annotation-processor/src/main/java/yajco/annotation/processor/AnnotationProcessor.java
@@ -2,37 +2,29 @@ package yajco.annotation.processor;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-import yajco.annotation.*;
-import yajco.annotation.config.Option;
+import yajco.annotation.Exclude;
 import yajco.annotation.config.Parser;
-import yajco.annotation.config.Skip;
-import yajco.annotation.reference.References;
 import yajco.generator.FilesGenerator;
 import yajco.generator.GeneratorException;
 import yajco.generator.parsergen.CompilerGenerator;
 import yajco.generator.util.ServiceFinder;
-import yajco.model.*;
-import yajco.model.pattern.Pattern;
-import yajco.model.pattern.PatternSupport;
-import yajco.model.pattern.impl.Factory;
-import yajco.model.type.*;
-import yajco.model.utilities.XMLLanguageFormatHelper;
+import yajco.model.Language;
 import yajco.printer.Printer;
 
 import javax.annotation.processing.AbstractProcessor;
 import javax.annotation.processing.RoundEnvironment;
 import javax.annotation.processing.SupportedAnnotationTypes;
 import javax.lang.model.SourceVersion;
-import javax.lang.model.element.*;
-import javax.lang.model.type.*;
-import javax.lang.model.type.ArrayType;
+import javax.lang.model.element.Element;
+import javax.lang.model.element.TypeElement;
+import javax.lang.model.type.MirroredTypesException;
+import javax.lang.model.type.TypeMirror;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.PrintWriter;
-import java.lang.reflect.Constructor;
-import java.lang.reflect.Field;
-import java.util.*;
-import java.util.Optional;
+import java.util.HashSet;
+import java.util.Properties;
+import java.util.Set;
 
 @SupportedAnnotationTypes({"yajco.annotation.config.Parser", "yajco.annotation.Exclude"})
 //Nutnost upravit reference resolver, ktory funguje len s jednym konstruktoroms
@@ -46,32 +38,18 @@ public class AnnotationProcessor extends AbstractProcessor {
     /**
      * Version string.
      */
-    private static final String VERSION = "0.5.1";
+    private static final String VERSION = "0.7.0";
     private static final String PROPERTY_SETTINGS_FILE = "/yajco.properties";
     private static final Logger logger = LoggerFactory.getLogger("YAJCO Annotation Processor");
     /**
      * Stored round environment.
      */
     private RoundEnvironment roundEnv;
+    private Properties baseProperties;
     private Properties properties;
-    private Set<String> excludes = new HashSet<>();
-    /**
-     * Builded language.
-     */
     private Language language;
-
-    /**
-     * Set for concepts imported from previous JARs and needed for full analysis.
-     */
-    private Set<Concept> conceptsToProcess = new HashSet<>();
-
-    /**
-     * Used for creation of string tokens defined by @StringToken annotation.
-     */
-    private int stringTokenId = 1;
-    private static final String DEFAULT_STRING_TOKEN_NAME = "STRING_TOKEN";
-    private static final String IDENTIFIER_TOKEN_NAME = "IDENTIFIER";
-    private static final String IDENTIFIER_TOKEN_REGEXP = "[a-zA-Z_][a-zA-Z0-9_]*";
+    private Set<String> excludes = new HashSet<>();
+    private Set<? extends Element> rootElements;
 
     @Override
     public SourceVersion getSupportedSourceVersion() {
@@ -90,134 +68,32 @@ public class AnnotationProcessor extends AbstractProcessor {
             return false;
         }
 
-        // Leave only @Parser annotation for later processing.
-        annotations.removeIf(typeElement -> typeElement.getQualifiedName().contentEquals(Exclude.class.getName()));
-
         // Initialize properties
-        properties = new Properties();
-        this.loadSettingsFromSettingsFile();
+        baseProperties = this.loadSettingsFromSettingsFile();
 
         // Check if YAJCo is not disabled.
-        if ("false".equalsIgnoreCase(properties.getProperty("yajco"))) {
+        if ("false".equalsIgnoreCase(baseProperties.getProperty("yajco"))) {
             logger.info("Property 'yajco' set to false - terminating YAJCo tool!");
             return false;
         }
 
         this.roundEnv = roundEnv;
+        rootElements = roundEnv.getRootElements();
         this.processExcludedElements();
 
         try {
-            if (annotations.size() == 1) {
-                //logger.info("YAJCo parser generator {}", VERSION);
+            if (hasParserAnnotation(annotations)) {
                 System.out.println("YAJCo parser generator " + VERSION);
 
                 Set<? extends Element> elements = roundEnv.getElementsAnnotatedWith(yajco.annotation.config.Parser.class);
-
                 if (elements.isEmpty()) {
                     return false;
                 }
 
                 // Process each @Parser annotation
                 for (Element parserAnnotationElement : elements) {
-                    // Initialize properties for this parser
-                    properties = new Properties();
-                    this.loadSettingsFromSettingsFile();
-
-                    // Disable class generating - annotation processor works on classes, don't generate new ones.
-                    properties.setProperty("yajco.generator.classgen.ClassGenerator", "false");
-
-                    Parser parserAnnotation = parserAnnotationElement.getAnnotation(Parser.class);
-                    this.extractOptionsFromParserAnnotation(parserAnnotation);
-                    this.extractLanguageAnnotation(parserAnnotationElement);
-
-                    // Extract the main element, package or type can be annotated with @Parser.
-                    ElementKind parserAnnotationElemKind = parserAnnotationElement.getKind();
-                    TypeElement mainElement;
-                    String mainElementName;
-                    if (parserAnnotationElemKind == ElementKind.PACKAGE) {
-                        mainElementName = parserAnnotation.mainNode();
-                        if (mainElementName.indexOf('.') == -1) {
-                            //TODO: Chyba v javac - ak nexistovala trieda tak ju vytvorilo ale nehlasilo null
-                            // ak som zavolal pre "Expression" vratilo sice null ale potom hlasilo duplicate class
-                            //mainElement = processingEnv.getElementUtils().getTypeElement(mainElementName);
-                            //mozno treba niekde v tools nastavit aby negenerovalo po otazke triedu ak neexistuje,
-                            //zda sa mi ze som to niekde videl v helpe
-                            mainElementName = ((PackageElement) parserAnnotationElement).getQualifiedName() + "." + mainElementName;
-                        }
-                        mainElement = processingEnv.getElementUtils().getTypeElement(mainElementName);
-                    } else if (parserAnnotationElemKind == ElementKind.CLASS || parserAnnotationElemKind == ElementKind.INTERFACE || parserAnnotationElemKind == ElementKind.ENUM) {
-                        mainElement = (TypeElement) parserAnnotationElement;
-                        mainElementName = mainElement.asType().toString();
-                        properties.setProperty("yajco.mainNode", mainElementName);
-                    } else {
-                        System.err.println("@Parser annotation can't be used on [" + parserAnnotationElemKind.toString() + "]\n");
-                        throw new GeneratorException("Annotation @Parser should annotate only package, class, interface or enum.");
-                    }
-
-                    if (mainElement == null) {
-                        throw new GeneratorException("Main language concept not found '" + parserAnnotation.mainNode() + "'");
-                    }
-
-                    //Map element to lines
-    //                Trees trees = Trees.instance(processingEnv);
-    //                SourcePositions sc = trees.getSourcePositions();
-    //                System.out.println("trees=" + trees + ", sc=" + sc);
-    //                TreePath path = trees.getPath(mainElement);
-    //                Tree tree = trees.getTree(mainElement);
-    //                CompilationUnitTree cut = path.getCompilationUnit();
-    //                LineMap lm = cut.getLineMap();
-    //                System.out.println("mainElement=" + mainElement + ", class=" + mainElement.getClass());
-    //                System.out.println("path=" + path);
-    //                System.out.println("cut=" + cut.getClass());
-    //                System.out.println("tree=" + tree.getClass());
-    //                System.out.println("lm=" + lm);
-    //                long startPosition = sc.getStartPosition(cut, tree);
-    //                long endPosition = sc.getEndPosition(cut, tree);
-    //                System.out.println("uri=" + cut.getSourceFile().toUri());
-    //                System.out.printf("Position (%d,%d) to (%d,%d)\n", lm.getLineNumber(startPosition), lm.getColumnNumber(startPosition), lm.getLineNumber(endPosition), lm.getColumnNumber(endPosition));
-
-
-                    // Create language.
-                    language = new Language(mainElement);
-                    // Add main package name == language name.
-                    String languageName = mainElementName.substring(0, mainElementName.lastIndexOf('.'));
-                    System.out.println("---- mainElementName: " + mainElementName + " == languageName: " + languageName);
-                    if (!languageName.isEmpty()) {
-                        language.setName(languageName);
-                    }
-
-                    // Add language concepts from included JARs.
-                    addLanguageConceptsFromIncludedJARs();
-
-                    // Start processing with the main element.
-                    System.out.println(" ? mainElement ? : " + mainElement);
-                    processTypeElement(mainElement);
-
-                    // Add tokens and skips into language.
-                    addTokensAndSkipsIntoLanguage(parserAnnotation, parserAnnotationElement);
-
-                    // Convert properties to language settings.
-                    language.setSettings(LanguageSetting.convertToLanguageSetting(properties));
-
-                    // Print recognized language to output.
-                    printLanguage();
-
-                    // Generate compiler.
-                    if (!("false".equalsIgnoreCase(properties.getProperty("yajco.generateParser")))) {
-                        String parserClassName = parserAnnotation.className();
-                        generateCompiler(parserClassName);
-                    }
-
-                    // Reset for next parser
-                    conceptsToProcess.clear();
-                    stringTokenId = 1;
+                    processParser(parserAnnotationElement);
                 }
-
-                // generates all new files
-//            GeneratorHelper generatorHelper = new GeneratorHelper(language, targetDirectory, properties);
-//            if (properties.containsKey("generateTools") && "true".equals(properties.getProperty("generateTools"))) {
-//                generatorHelper.generateAllExceptModelClassFiles();
-//            }
 
                 // Generate all tools.
                 generateAllTools();
@@ -233,19 +109,54 @@ public class AnnotationProcessor extends AbstractProcessor {
         return false;
     }
 
+    private static boolean hasParserAnnotation(Set<? extends TypeElement> annotations) {
+        return annotations.stream().anyMatch(
+            typeElement -> typeElement.getQualifiedName().contentEquals(Parser.class.getName()));
+    }
+
+    private void processParser(Element parserAnnotationElement) {
+        // Initialize properties for this parser
+        properties = createParserProperties(baseProperties);
+
+        // Disable class generating - annotation processor works on classes, don't generate new ones.
+        properties.setProperty("yajco.generator.classgen.ClassGenerator", "false");
+
+        Parser parserAnnotation = parserAnnotationElement.getAnnotation(Parser.class);
+        LanguageModelBuilder modelBuilder = new LanguageModelBuilder(properties, processingEnv, rootElements, excludes);
+        language = modelBuilder.createLanguageModel(parserAnnotationElement, parserAnnotation);
+
+        printLanguage(language);
+
+        // Generate compiler.
+        if (!("false".equalsIgnoreCase(properties.getProperty("yajco.generateParser")))) {
+            String parserClassName = parserAnnotation.className();
+            generateCompiler(parserClassName);
+        }
+    }
+
     /**
      * Loads settings from settings file to Properties object.
      */
-    private void loadSettingsFromSettingsFile() {
+    private Properties loadSettingsFromSettingsFile() {
+        Properties loadedProperties = new Properties();
         try {
             InputStream inputStream = getClass().getResourceAsStream(PROPERTY_SETTINGS_FILE);
-            properties.load(inputStream);
-            logger.debug("Loaded config from file: {}", properties);
+            loadedProperties.load(inputStream);
+            logger.debug("Loaded config from file: {}", loadedProperties);
         } catch (Exception e) {
             // LOG it but don't do anything, it is not an error
             logger.info("Cannot find or load {} file in classpath. Will use only @Parser options.", PROPERTY_SETTINGS_FILE);
             logger.debug("Loading config file: {}", e.getLocalizedMessage());
         }
+        return loadedProperties;
+    }
+
+    private static Properties createParserProperties(Properties baseProperties) {
+        Properties parserProperties = new Properties();
+        if (baseProperties != null) {
+            parserProperties.putAll(baseProperties);
+        }
+        return parserProperties;
     }
 
     /**
@@ -275,223 +186,9 @@ public class AnnotationProcessor extends AbstractProcessor {
     }
 
     /**
-     * Collects all options from @Parser annotation and store them to Properties object. Sets className and mainNode
-     * if they are defined in @Parser annotation.
-     *
-     * @param parserAnnotation @Parser annotation object.
-     */
-    private void extractOptionsFromParserAnnotation(Parser parserAnnotation) {
-        for (Option option : parserAnnotation.options()) {
-            properties.setProperty(option.name(), option.value());
-        }
-
-        if (!parserAnnotation.className().isEmpty()) {
-            properties.setProperty("yajco.className", parserAnnotation.className());
-        }
-        if (!parserAnnotation.mainNode().isEmpty()) {
-            properties.setProperty("yajco.mainNode", parserAnnotation.mainNode());
-        }
-    }
-
-    /**
-     * Extracts metadata from {@code @Language} annotation and stores it in properties.
-     * When {@code @Language} is present, IR generation is automatically enabled.
-     *
-     * @param element The element annotated with both @Parser and potentially @Language.
-     */
-    private void extractLanguageAnnotation(Element element) {
-        yajco.annotation.config.Language lang = element.getAnnotation(yajco.annotation.config.Language.class);
-        if (lang == null) {
-            return;
-        }
-
-        // Auto-enable IR generation when @Language is present
-        String tools = properties.getProperty("yajco.generateTools", "");
-        if (!tools.toLowerCase().contains("ir") && !tools.toLowerCase().contains("all")) {
-            properties.setProperty("yajco.generateTools",
-                tools.isEmpty() ? "ir" : tools + ",ir");
-        }
-
-        // Language name
-        if (!lang.name().isEmpty()) {
-            properties.setProperty("yajco.ir.languageName", lang.name());
-        }
-
-        // Description
-        if (!lang.description().isEmpty()) {
-            properties.setProperty("yajco.ir.description", lang.description());
-        }
-
-        // Version
-        if (!lang.version().isEmpty()) {
-            properties.setProperty("yajco.ir.version", lang.version());
-        }
-
-        // File extensions (joined as comma-separated string)
-        if (lang.fileExtensions().length > 0) {
-            properties.setProperty("yajco.ir.fileExtensions",
-                String.join(",", lang.fileExtensions()));
-        }
-
-        // Comment syntax — stored as explicit properties for the IR generator
-        if (!lang.lineComment().isEmpty()) {
-            properties.setProperty("yajco.ir.lineComment", lang.lineComment());
-        }
-        if (lang.blockComment().length == 2) {
-            properties.setProperty("yajco.ir.blockComment.start", lang.blockComment()[0]);
-            properties.setProperty("yajco.ir.blockComment.end", lang.blockComment()[1]);
-        }
-
-        // IR file name defaults to {languageName}.ir.json if not already set
-        if (!properties.containsKey("yajco.ir.file") && !lang.name().isEmpty()) {
-            properties.setProperty("yajco.ir.file", lang.name() + ".ir.json");
-        }
-    }
-
-    /**
-     * Generates skip rules from {@code @Language} comment syntax and adds them
-     * to the parser's skip list. This allows users to specify comment syntax once
-     * in {@code @Language} without needing a separate {@code @Skip} annotation.
-     *
-     * @param element The element annotated with @Language.
-     * @param existingSkips The skip list from @Parser to check for duplicates.
-     * @return Additional SkipDef entries to add to the language.
-     */
-    private List<SkipDef> buildCommentSkipsFromLanguage(Element element, List<SkipDef> existingSkips) {
-        yajco.annotation.config.Language lang = element.getAnnotation(yajco.annotation.config.Language.class);
-        if (lang == null) {
-            return Collections.emptyList();
-        }
-
-        // Collect existing skip patterns to avoid duplicates
-        Set<String> existingPatterns = new HashSet<>();
-        for (SkipDef skip : existingSkips) {
-            existingPatterns.add(skip.getRegexp());
-        }
-
-        List<SkipDef> commentSkips = new ArrayList<>();
-
-        // Line comment: prefix → prefix + ".*"
-        if (!lang.lineComment().isEmpty()) {
-            String pattern = escapeRegex(lang.lineComment()) + ".*";
-            if (!existingPatterns.contains(pattern)) {
-                commentSkips.add(new SkipDef(pattern));
-            }
-        }
-
-        // Block comment: [start, end] → start + "(?:(?!" + end + ")[\\s\\S])*" + end
-        if (lang.blockComment().length == 2) {
-            String start = escapeRegex(lang.blockComment()[0]);
-            String end = escapeRegex(lang.blockComment()[1]);
-            String pattern = start + "(?:(?!" + end + ")[\\s\\S])*" + end;
-            if (!existingPatterns.contains(pattern)) {
-                commentSkips.add(new SkipDef(pattern));
-            }
-        }
-
-        return commentSkips;
-    }
-
-    /**
-     * Loads language concepts, skips and tokens from languages included as JAR files.
-     */
-    private void addLanguageConceptsFromIncludedJARs() {
-        List<Language> includedLanguages = XMLLanguageFormatHelper.getAllLanguagesFromXML();
-        System.out.println("Loaded external language specifications: " + includedLanguages.size());
-        for (Language incLang : includedLanguages) {
-            System.out.print("Loaded from JAR: ");
-            for (Concept concept : incLang.getConcepts()) {
-                System.out.print(concept.getName() + ", ");
-            }
-            System.out.println();
-
-            addToListAsSet(language.getSkips(), incLang.getSkips(), true);
-            addToListAsSet(language.getTokens(), incLang.getTokens(), true);
-            conceptsToProcess.addAll(incLang.getConcepts());
-            language.getConcepts().addAll(incLang.getConcepts());
-        }
-    }
-
-    /**
-     * Adds tokens and skips defined in @Parser annotation into language.
-     * Also adds comment skip rules from @Language if present.
-     *
-     * @param parserAnnotation @Parser annotation object
-     * @param parserAnnotationElement The annotated element (for reading @Language)
-     */
-    private void addTokensAndSkipsIntoLanguage(Parser parserAnnotation, Element parserAnnotationElement) {
-        List<TokenDef> tokens = new ArrayList<>();
-        List<SkipDef> skips = new ArrayList<>();
-        for (yajco.annotation.config.TokenDef tokenDef : parserAnnotation.tokens()) {
-            tokens.add(new TokenDef(tokenDef.name(), tokenDef.regexp(), tokenDef));
-        }
-        for (Skip skip : parserAnnotation.skips()) {
-            String regexp = convertSkipToRegexp(skip);
-            skips.add(new SkipDef(regexp, skip));
-        }
-
-        // Add default white space for skips if empty.
-        if (skips.isEmpty()) {
-            skips.add(new SkipDef("\\s"));
-        }
-
-        // Add comment skip rules from @Language (avoids duplicate @Skip for comments)
-        List<SkipDef> commentSkips = buildCommentSkipsFromLanguage(parserAnnotationElement, skips);
-        skips.addAll(commentSkips);
-
-        addToListAsSet(language.getSkips(), skips, true);
-        addToListAsSet(language.getTokens(), tokens, true);
-    }
-
-    /**
-     * Converts @Skip annotation parameters into a regular expression.
-     * Supports syntactic sugar for whitespace and comment patterns.
-     *
-     * @param skip @Skip annotation object
-     * @return Regular expression string
-     */
-    private String convertSkipToRegexp(Skip skip) {
-        // If value is explicitly set, use it directly (highest priority)
-        if (!skip.value().isEmpty()) {
-            return skip.value();
-        }
-
-        // Handle whitespace flag
-        if (skip.whitespace()) {
-            return "\\s";
-        }
-
-        // Handle comment patterns with start and optional end
-        if (!skip.start().isEmpty()) {
-            String start = escapeRegex(skip.start());
-            if (!skip.end().isEmpty()) {
-                // Multi-line comment with explicit end: start...end
-                String end = escapeRegex(skip.end());
-                return start + "(?:(?!" + end + ")[\\s\\S])*" + end;
-            } else {
-                // Single-line comment: start until end of line
-                return start + ".*";
-            }
-        }
-
-        // If nothing is specified, return empty string (should not happen in practice)
-        return "";
-    }
-
-    /**
-     * Escapes special regex characters in a literal string.
-     *
-     * @param literal String to escape
-     * @return Escaped string safe for use in regex
-     */
-    private String escapeRegex(String literal) {
-        return literal.replaceAll("([\\\\.*+?^${}()|\\[\\]])", "\\\\$1");
-    }
-
-    /**
      * Prints created language.
      */
-    private void printLanguage() {
+    private static void printLanguage(Language language) {
         Printer printer = new Printer();
         System.out.println("--------------------------------------------------------------------------------------------------------");
         printer.printLanguage(new PrintWriter(System.out), language);
@@ -505,1012 +202,6 @@ public class AnnotationProcessor extends AbstractProcessor {
         Set<FilesGenerator> tools = ServiceFinder.findFilesGenerators(properties);
         for (FilesGenerator filesGenerator : tools) {
             filesGenerator.generateFiles(language, processingEnv.getFiler(), properties);
-        }
-    }
-
-    /**
-     * Processes language model elements.
-     *
-     * @param typeElement Language model element to process.
-     * @return Processed language concept.
-     */
-    private Concept processTypeElement(TypeElement typeElement) {
-        return processTypeElement(typeElement, null);
-    }
-
-    /**
-     * Processes language model elements and creates unique language concepts for all of them.
-     *
-     * @param typeElement Language model element to process.
-     * @param superConcept Parent concept.
-     * @return Processed language concept.
-     */
-    private Concept processTypeElement(TypeElement typeElement, Concept superConcept) {
-        String name = typeElement.getQualifiedName().toString();
-        System.out.println("---->>> Name: " + name + " [kind:" + typeElement.getKind() + "]");
-        if (excludes.contains(name)) {
-            return null;
-        }
-
-        if (language.getName() != null && !language.getName().isEmpty() && name.startsWith(language.getName())) {
-            name = name.substring(language.getName().length() + 1); // +1 because of dot after package name '.'
-        }
-
-        Concept concept = language.getConcept(name);
-        if (concept != null) { // Already processed
-            if (superConcept != null) { // Set parent
-                concept.setParent(superConcept);
-            }
-            // TODO:toto som tu doplnil len docasne na vyskusanie pre podporu kompozicie jazykov, treba to cele prehodnotit, lebo sa to nachadza aj na konci metody
-            //processDirectSubclasses(typeElement, concept);
-            if (conceptsToProcess.contains(concept)) {
-                conceptsToProcess.remove(concept);
-            } else {
-                return concept;
-            }
-        } else {
-            // Create concept.
-            concept = new Concept(name, typeElement);
-            concept.setParent(superConcept); //Set parent
-            language.addConcept(concept);
-        }
-
-        processTypeElementAccordingToKind(typeElement, concept);
-
-        // Add concept pattern from annotations (ConceptPattern).
-        addPatternsFromAnnotations(typeElement, concept);
-        processDirectSubclasses(typeElement, concept);
-        return concept;
-    }
-
-    /**
-     * Processes language model element according to its kind.
-     *
-     * @param typeElement Language model element.
-     * @param concept Language concept for representing language model element.
-     */
-    private void processTypeElementAccordingToKind(TypeElement typeElement, Concept concept) {
-        if (typeElement.getKind() == ElementKind.ENUM) { // Enum type
-            processEnum(concept, typeElement);
-        } else if (typeElement.getKind() == ElementKind.CLASS) { // Class
-            System.out.println(" modifiers: " + typeElement.getModifiers());
-            if (typeElement.getModifiers().contains(Modifier.ABSTRACT)) { // Abstract class
-                processAbstractClass(concept, typeElement);
-            } else {  //Concrete class
-                processConcreteClass(concept, typeElement);
-            }
-        } else if (typeElement.getKind() == ElementKind.INTERFACE) { // Interface
-            processInterface(concept, typeElement);
-        } else {
-            throw new GeneratorException("Not supported type in model '" + typeElement + "'");
-        }
-    }
-
-    /**
-     * Processes Enum language model elements.
-     *
-     * @param concept Language concept representing language model element.
-     * @param typeElement Language model element.
-     */
-    private void processEnum(Concept concept, TypeElement typeElement) {
-        concept.addPattern(new yajco.model.pattern.impl.Enum());
-        for (Element element : typeElement.getEnclosedElements()) {
-            if (element.getKind() != ElementKind.ENUM_CONSTANT) {
-                continue; // Skip non enum constants.
-            }
-
-            Token tokenAnnotation = element.getAnnotation(Token.class);
-            Notation notation = new Notation(typeElement);
-            TokenPart tokenPart;
-            if (tokenAnnotation != null) {
-                tokenPart = new TokenPart(tokenAnnotation.value(), tokenAnnotation);
-            } else {
-                tokenPart = new TokenPart(element.getSimpleName().toString(), element);
-            }
-            notation.addPart(tokenPart);
-            concept.addNotation(notation);
-        }
-    }
-
-    /**
-     * Processes concrete classes of language model.
-     *
-     * @param concept Language concept representing language model element.
-     * @param classElement Language model element.
-     */
-    private void processConcreteClass(Concept concept, TypeElement classElement) {
-        defineAbstractSytax(concept, classElement);
-        defineConcreteSyntax(concept, classElement);
-    }
-
-    /**
-     * Parses concepts concrete syntax.
-     *
-     * @param concept Language concept representing language model element.
-     * @param classElement Language model element.
-     */
-    private void defineConcreteSyntax(Concept concept, TypeElement classElement) {
-        Set<ExecutableElement> constructors = getConstructorsAndFactoryMethods(classElement);
-
-        // Check for class-level @Before, @Keyword, and @After annotations
-        Before beforeClassAnnotation = classElement.getAnnotation(Before.class);
-        Keyword keywordClassAnnotation = classElement.getAnnotation(Keyword.class);
-        After afterClassAnnotation = classElement.getAnnotation(After.class);
-
-        // If there are no constructors but class has @Before, @Keyword, or @After annotations, create a default constructor notation
-        if (constructors.isEmpty() && (beforeClassAnnotation != null || keywordClassAnnotation != null || afterClassAnnotation != null)) {
-            Notation defaultNotation = new Notation(classElement);
-
-            // Apply class-level @Before annotation
-            if (beforeClassAnnotation != null) {
-                addTokenParts(defaultNotation, beforeClassAnnotation.value());
-            }
-
-            // Apply class-level @Keyword annotation
-            if (keywordClassAnnotation != null) {
-                addTokenParts(defaultNotation, keywordClassAnnotation.value());
-            }
-
-            // Apply class-level @After annotation
-            if (afterClassAnnotation != null) {
-                addTokenParts(defaultNotation, afterClassAnnotation.value());
-            }
-
-            concept.addNotation(defaultNotation);
-        }
-
-        for (ExecutableElement constructor : constructors) {
-            Notation notation = new Notation(constructor);
-
-            // Apply class-level @Before annotation first, if present
-            if (beforeClassAnnotation != null) {
-                addTokenParts(notation, beforeClassAnnotation.value());
-            }
-
-            // Apply class-level @Keyword annotation, if present
-            if (keywordClassAnnotation != null) {
-                addTokenParts(notation, keywordClassAnnotation.value());
-            }
-
-            // Then apply constructor-level @Before annotation
-            if (constructor.getAnnotation(Before.class) != null) {
-                addTokenParts(notation, constructor.getAnnotation(Before.class).value());
-            }
-
-            // Then apply constructor-level @Keyword annotation
-            if (constructor.getAnnotation(Keyword.class) != null) {
-                addTokenParts(notation, constructor.getAnnotation(Keyword.class).value());
-            }
-
-            // @UnorderedParameters annotation.
-            UnorderedParameters unorderedParametersAnnotation = constructor.getAnnotation(UnorderedParameters.class);
-            MixedRepetition mixedRepetitionAnnotation = constructor.getAnnotation(MixedRepetition.class);
-
-            if (unorderedParametersAnnotation != null) {
-                processUnorderedParamsConstructor(concept, constructor, notation, unorderedParametersAnnotation);
-            } else if (mixedRepetitionAnnotation != null) {
-                processMixedRepetitionConstructor(concept, constructor, notation, mixedRepetitionAnnotation);
-            } else {
-                for (VariableElement paramElement : constructor.getParameters()) {
-                    processParameter(concept, notation, paramElement);
-                }
-            }
-
-            // Apply constructor-level @After annotation
-            if (constructor.getAnnotation(After.class) != null) {
-                addTokenParts(notation, constructor.getAnnotation(After.class).value());
-            }
-
-            // Then apply class-level @After annotation, if present
-            if (afterClassAnnotation != null) {
-                addTokenParts(notation, afterClassAnnotation.value());
-            }
-
-            concept.addNotation(notation);
-            if (constructor.getKind() == ElementKind.METHOD) {
-                notation.addPattern(new Factory(constructor.getSimpleName().toString()));
-            }
-
-            //TODO: odstranit pri prenesesni @Operator na triedu
-            // Add concept pattern from annotations (Type).
-            addPatternsFromAnnotations(constructor, concept);
-        }
-    }
-
-    /**
-     * Processes constructor annotated with @UnorderedParameters annotation.
-     *
-     * @param concept Language concept.
-     * @param notation Language concept notation.
-     * @param unorderedParametersAnnotation UnorderedParameters annotation
-     */
-    private void processUnorderedParamsConstructor(Concept concept, ExecutableElement constructor, Notation notation, UnorderedParameters unorderedParametersAnnotation) {
-        int excludedCount = 0;
-        int unorderedCount = 0;
-        boolean cantBeExcluded = false;
-        boolean cantBeUnordered = false;
-
-        for (VariableElement paramElement : constructor.getParameters()) {
-            if (Arrays.asList(unorderedParametersAnnotation.exclude()).contains(paramElement.getSimpleName().toString())) {
-                processParameter(concept, notation, paramElement);
-                excludedCount++;
-                cantBeUnordered = unorderedCount > 0 && excludedCount > 0;
-            } else if (getType(paramElement.asType()) instanceof OptionalType)  {
-                UnorderedParamPart unorderedParamPart = new UnorderedParamPart(null);
-                OptionalPart optionalPart = (OptionalPart) processCompoundParameter(concept, paramElement, new OptionalPart(null));
-                unorderedParamPart.addPart(optionalPart);
-                notation.addPart(unorderedParamPart);
-                unorderedCount++;
-                cantBeExcluded = unorderedCount > 0 && excludedCount > 0;
-            } else {
-                UnorderedParamPart unorderedParamPart = new UnorderedParamPart(null);
-                processCompoundParameter(concept, paramElement, unorderedParamPart);
-                notation.addPart(unorderedParamPart);
-                unorderedCount++;
-                cantBeExcluded = unorderedCount > 0 && excludedCount > 0;
-            }
-
-            if (cantBeExcluded && cantBeUnordered) {
-                throw new GeneratorException("Excluded parameter can't be in the middle of unordered parameters.");
-            }
-        }
-    }
-
-    /**
-     * Processes constructor annotated with @MixedRepetition annotation.
-     *
-     * @param concept Language concept.
-     * @param constructor Constructor or factory method element.
-     * @param notation Language concept notation.
-     * @param mixedRepetitionAnnotation MixedRepetition annotation
-     */
-    private void processMixedRepetitionConstructor(Concept concept, ExecutableElement constructor, Notation notation, MixedRepetition mixedRepetitionAnnotation) {
-        MixedRepetitionPart mixedRepetitionPart = new MixedRepetitionPart(null);
-
-        for (VariableElement paramElement : constructor.getParameters()) {
-            String paramName = paramElement.getSimpleName().toString();
-
-            // Check if parameter is excluded
-            if (Arrays.asList(mixedRepetitionAnnotation.exclude()).contains(paramName)) {
-                processParameter(concept, notation, paramElement);
-            } else {
-                // Parameter should be a collection type (List or Array)
-                Type paramType = getType(paramElement.asType());
-
-                if (!(paramType instanceof ListType || paramType instanceof ArrayType)) {
-                    throw new GeneratorException(
-                        "Parameter '" + paramName + "' in @MixedRepetition must be a List or Array type. Found: " + paramType.getClass().getSimpleName()
-                    );
-                }
-
-                // Create property reference part for this collection parameter
-                Property property = concept.getProperty(paramName);
-                if (property == null) {
-                    property = new Property(paramName, paramType, null);
-                    concept.addProperty(property);
-                }
-
-                PropertyReferencePart propertyRefPart = new PropertyReferencePart(property, paramElement);
-
-                // Add patterns from annotations (e.g., @Before, @After on individual parameters)
-                addPatternsFromAnnotations(paramElement, propertyRefPart);
-
-                // Add this property reference to the mixed repetition part
-                mixedRepetitionPart.addPart(propertyRefPart);
-            }
-        }
-
-        // Add the mixed repetition part to the notation
-        if (mixedRepetitionPart.getParts().size() > 0) {
-            notation.addPart(mixedRepetitionPart);
-        }
-    }
-
-    /**
-     * Parses concepts abstract syntax.
-     *
-     * @param concept Language concept representing language model element.
-     * @param classElement Language model element.
-     */
-    private void defineAbstractSytax(Concept concept, TypeElement classElement) {
-        System.out.println("starting ProcessConcreteClass method");
-        for (Element element : classElement.getEnclosedElements()) {
-            System.out.println("- enclosedElement: " + element.getSimpleName().toString() + "[" + element.getKind() + "]");
-            if (element.getKind().isField()) {
-                System.out.println("+++ " + classElement.toString() + "> " + element.toString());
-                VariableElement fieldElement = (VariableElement) element;
-
-                // Add only fields with property patterns (PropertyPattern).
-                if (hasPatternAnnotations(fieldElement)) {
-                    Property property = new Property(fieldElement.getSimpleName().toString(), getType(fieldElement.asType()), fieldElement);
-                    addPatternsFromAnnotations(fieldElement, property);
-                    concept.addProperty(property);
-                }
-            }
-        }
-    }
-
-    /**
-     * Processes abstract classes of language model elements
-     *
-     * @param concept Language concept representing language model element.
-     * @param typeElement Language model element.
-     */
-    private void processAbstractClass(Concept concept, TypeElement typeElement) {
-        //TODO: toto je len docasne pre testovanie a pokial sa ujasni ako to chceme
-        //processConcreteClass(concept, typeElement);
-    }
-
-    /**
-     * Processes interfaces of language model elements
-     *
-     * @param concept Language concept representing language model element.
-     * @param typeElement Language model element.
-     */
-    private void processInterface(Concept concept, TypeElement typeElement) {
-    }
-
-    /**
-     * Processes parameters of constructor or factory method in language model.
-     *
-     * @param concept Language concept.
-     * @param notation Notation of language concept.
-     * @param paramElement Parameter of constructor or factory method.
-     */
-    private void processParameter(Concept concept, Notation notation, VariableElement paramElement) {
-        Type type = getType(paramElement.asType());
-        yajco.annotation.Flag flagAnnotation = paramElement.getAnnotation(yajco.annotation.Flag.class);
-
-        // Handle @Flag annotation on boolean parameters
-        if (flagAnnotation != null) {
-            if (!(type instanceof yajco.model.type.PrimitiveType
-                    && ((yajco.model.type.PrimitiveType) type).getPrimitiveTypeConst() == PrimitiveTypeConst.BOOLEAN)) {
-                throw new GeneratorException("@Flag annotation can only be used on boolean parameters");
-            }
-
-            String paramName = paramElement.getSimpleName().toString();
-            Property property = concept.getProperty(paramName);
-            if (property == null) {
-                property = new Property(paramName, type, null);
-                concept.addProperty(property);
-            }
-
-            // Create an optional part containing the flag token
-            OptionalPart optionalPart = new OptionalPart(null);
-            optionalPart.addPart(new TokenPart(flagAnnotation.value()));
-
-            // Add property reference with Flag pattern
-            PropertyReferencePart propertyRefPart = new PropertyReferencePart(property, paramElement);
-            propertyRefPart.addPattern(new yajco.model.pattern.impl.Flag(flagAnnotation.value(), flagAnnotation));
-            optionalPart.addPart(propertyRefPart);
-
-            notation.addPart(optionalPart);
-        } else if (type instanceof OptionalType) {
-            OptionalPart optionalPart = (OptionalPart) processCompoundParameter(concept, paramElement, new OptionalPart(null));
-            notation.addPart(optionalPart);
-        } else {
-            // @Keyword annotation.
-            if (paramElement.getAnnotation(Keyword.class) != null) {
-                addTokenParts(notation, paramElement.getAnnotation(Keyword.class).value());
-            }
-
-            // @Before annotation.
-            if (paramElement.getAnnotation(Before.class) != null) {
-                addTokenParts(notation, paramElement.getAnnotation(Before.class).value());
-            }
-
-            String paramName = paramElement.getSimpleName().toString();
-            TypeMirror typeMirror = paramElement.asType();
-            References references = paramElement.getAnnotation(References.class);
-            Token tokenAnnotation = paramElement.getAnnotation(Token.class);
-            StringToken stringTokenAnnotation = paramElement.getAnnotation(StringToken.class);
-            BindingNotationPart part = null;
-
-            if (references != null) { // @References annotation.
-                //TODO: zatial nie je podpora pre polia referencii, treba to vsak doriesit
-                type = getSimpleType(typeMirror);
-                LocalVariablePart localVariablePart = new LocalVariablePart(paramName, type, paramElement);
-                notation.addPart(localVariablePart);
-
-                part = processReferencedConcept(concept, paramElement, references, localVariablePart);
-            } else { // Property reference.
-                Property property = concept.getProperty(paramName);
-                if (property == null) {
-                    property = new Property(paramName, getType(typeMirror), null);
-                    concept.addProperty(property);
-                }
-
-                part = new PropertyReferencePart(property, paramElement);
-                notation.addPart(part);
-            }
-
-            if (tokenAnnotation != null) {
-                part.addPattern(new yajco.model.pattern.impl.Token(tokenAnnotation.value(), tokenAnnotation));
-            } else if (stringTokenAnnotation != null) {
-                TokenDef tokenDef = createStringTokenDef(stringTokenAnnotation);
-                part.addPattern(new yajco.model.pattern.impl.Token(tokenDef.getName(), tokenAnnotation));
-            } else if (references != null) {
-                // Automatically add IDENTIFIER token for @References parameters
-                ensureIdentifierTokenExists();
-                part.addPattern(new yajco.model.pattern.impl.Token(IDENTIFIER_TOKEN_NAME, references));
-            } else if (part instanceof PropertyReferencePart) {
-                // Check if the referenced property has @Identifier pattern
-                PropertyReferencePart propRefPart = (PropertyReferencePart) part;
-                if (propertyHasIdentifierPattern(propRefPart.getProperty())) {
-                    // Automatically add IDENTIFIER token for properties with @Identifier
-                    ensureIdentifierTokenExists();
-                    part.addPattern(new yajco.model.pattern.impl.Token(IDENTIFIER_TOKEN_NAME, paramElement));
-                }
-            }
-
-            // Add notation part pattern from annotations (NotationPartPattern).
-            addPatternsFromAnnotations(paramElement, part);
-
-            // @After annotation.
-            if (paramElement.getAnnotation(After.class) != null) {
-                addTokenParts(notation, paramElement.getAnnotation(After.class).value());
-            }
-        }
-    }
-
-    /**
-     * Processes compound parameters (Parameters which know their whole concrete syntax).
-     *
-     * @param concept Language concept.
-     * @param paramElement Parameter of constructor or factory method.
-     * @param notationPart Compound notation part.
-     *
-     * @return Compound notation part.
-     */
-    private CompoundNotationPart processCompoundParameter(Concept concept, VariableElement paramElement, CompoundNotationPart notationPart) {
-        // @Keyword annotation.
-        if (paramElement.getAnnotation(Keyword.class) != null) {
-            for (String value : paramElement.getAnnotation(Keyword.class).value()) {
-                notationPart.addPart(new TokenPart(value));
-            }
-        }
-
-        // @Before annotation.
-        if (paramElement.getAnnotation(Before.class) != null) {
-            for (String value : paramElement.getAnnotation(Before.class).value()) {
-                notationPart.addPart(new TokenPart(value));
-            }
-        }
-
-        String paramName = paramElement.getSimpleName().toString();
-        TypeMirror typeMirror = paramElement.asType();
-        References references = paramElement.getAnnotation(References.class);
-        Token tokenAnnotation = paramElement.getAnnotation(Token.class);
-        StringToken stringTokenAnnotation = paramElement.getAnnotation(StringToken.class);
-        BindingNotationPart part;
-
-        if (references != null) { // @References annotation.
-            Type type;
-            List<? extends TypeMirror> types = ((DeclaredType) typeMirror).getTypeArguments();
-            if (processingEnv.getTypeUtils().asElement(typeMirror).toString().equals(Optional.class.getName())) {
-                type = getSimpleType(types.get(types.size() - 1));
-            } else {
-                type = getSimpleType(typeMirror);
-            }
-            LocalVariablePart localVariablePart = new LocalVariablePart(paramName, type, paramElement);
-            notationPart.addPart(localVariablePart);
-            part = processReferencedConcept(concept, paramElement, references, localVariablePart);
-        } else { // Property reference.
-            Property property = concept.getProperty(paramName);
-            if (property == null) {
-                property = new Property(paramName, getType(typeMirror), null);
-                concept.addProperty(property);
-            }
-
-            part = new PropertyReferencePart(property, paramElement);
-            notationPart.addPart(part);
-        }
-
-        if (tokenAnnotation != null) {
-            part.addPattern(new yajco.model.pattern.impl.Token(tokenAnnotation.value(), tokenAnnotation));
-        } else if (stringTokenAnnotation != null) {
-            TokenDef tokenDef = createStringTokenDef(stringTokenAnnotation);
-            part.addPattern(new yajco.model.pattern.impl.Token(tokenDef.getName(), tokenAnnotation));
-        }
-
-        // Add notation part pattern from annotations (NotationPartPattern).
-        addPatternsFromAnnotations(paramElement, part);
-
-        // @After annotation.
-        if (paramElement.getAnnotation(After.class) != null) {
-            for (String value : paramElement.getAnnotation(After.class).value()) {
-                notationPart.addPart(new TokenPart(value));
-            }
-        }
-
-        return notationPart;
-    }
-
-    /**
-     * Creates token for string token and adds it to language.
-     *
-     * @param stringTokenAnnotation StringToken annotation.
-     * @return TokenDef
-     */
-    private TokenDef createStringTokenDef(StringToken stringTokenAnnotation) {
-        String regex = formatStringTokenRegex(stringTokenAnnotation);
-        TokenDef tokenDef = null;
-
-        for (TokenDef token: language.getTokens()) {
-            if (token.getName().contains(DEFAULT_STRING_TOKEN_NAME) && token.getRegexp().equals(regex)) {
-                // Use existing string token with the same regex.
-                tokenDef = token;
-            }
-        }
-
-        if (tokenDef == null) {
-            tokenDef = new TokenDef(DEFAULT_STRING_TOKEN_NAME + "_" + stringTokenId++, regex);
-        }
-
-        // Add string token to language.
-        addToListAsSet(language.getTokens(), Collections.singletonList(tokenDef),false);
-
-        return tokenDef;
-    }
-
-    /**
-     * Ensures IDENTIFIER token exists in the language definition.
-     * If the token doesn't exist, it creates and adds it automatically.
-     *
-     * @return TokenDef for IDENTIFIER token
-     */
-    private TokenDef ensureIdentifierTokenExists() {
-        // Check if IDENTIFIER token already exists
-        for (TokenDef token : language.getTokens()) {
-            if (token.getName().equals(IDENTIFIER_TOKEN_NAME)) {
-                return token;
-            }
-        }
-
-        // Create new IDENTIFIER token
-        TokenDef tokenDef = new TokenDef(IDENTIFIER_TOKEN_NAME, IDENTIFIER_TOKEN_REGEXP);
-
-        // Add IDENTIFIER token to language
-        addToListAsSet(language.getTokens(), Collections.singletonList(tokenDef), false);
-
-        return tokenDef;
-    }
-
-    /**
-     * Checks if a property has an @Identifier pattern.
-     *
-     * @param property Property to check
-     * @return true if property has @Identifier pattern, false otherwise
-     */
-    private boolean propertyHasIdentifierPattern(Property property) {
-        if (property == null) {
-            return false;
-        }
-        for (Pattern pattern : property.getPatterns()) {
-            if (pattern instanceof yajco.model.pattern.impl.Identifier) {
-                return true;
-            }
-        }
-        return false;
-    }
-
-    /**
-     * Formats regex from @StringToken annotation. Regex is used to match strings.
-     *
-     * @param stringTokenAnnotation StringToken annotation
-     * @return Regex for matching strings.
-     */
-    private String formatStringTokenRegex(StringToken stringTokenAnnotation) {
-        String delimiter = stringTokenAnnotation.delimiter();
-
-        if (delimiter.equals("\"") || delimiter.equals("'") || delimiter.equals("\\")) {
-            delimiter = "\\" + stringTokenAnnotation.delimiter();
-        }
-
-        return delimiter + "(?:\\\\" + delimiter + "|[^" + delimiter + "])*?" + delimiter;
-    }
-
-    /**
-     * Processes referenced concept.
-     *
-     * @param concept Language concept.
-     * @param paramElement Parameter of constructor or factory method.
-     * @param references References annotation.
-     * @param part  Local variable notation part.
-     * @return Binding notation part.
-     */
-    private BindingNotationPart processReferencedConcept(Concept concept, VariableElement paramElement, References references, LocalVariablePart part) {
-        String paramName = paramElement.getSimpleName().toString();
-        try {
-            references.value();
-        } catch (MirroredTypeException e) {
-            TypeElement referencedTypeElement = (TypeElement) processingEnv.getTypeUtils().asElement(e.getTypeMirror());
-            Concept referencedConcept = processTypeElement(referencedTypeElement);
-            Property property = null;
-            if (!references.field().isEmpty()) {
-                property = concept.getProperty(references.field());
-            }
-            if (property == null) {
-                property = findReferencedProperty(paramElement, referencedConcept, references.field());
-                if (property == null) {
-                    String propertyName;
-                    if (references.field().isEmpty()) {
-                        propertyName = paramName;
-                    } else {
-                        propertyName = references.field();
-                    }
-                    property = new Property(propertyName, new yajco.model.type.ReferenceType(referencedConcept, referencedTypeElement), e);
-                }
-                concept.addProperty(property);
-            }
-            // If names of notationPart and referenced property are identical, no need to fill property data to References pattern.
-            if (property.getName().equals(paramName)) {
-                property = null;
-            }
-            part.addPattern(new yajco.model.pattern.impl.References(referencedConcept, property, references));
-        }
-        return part;
-    }
-
-    /**
-     * Finds referenced property.
-     *
-     * @param paramElement Parameter of constructor or factory method in language model.
-     * @param referencedConcept Referenced concept.
-     * @param proposedName Referenced field name.
-     * @return Referenced property.
-     */
-    private Property findReferencedProperty(VariableElement paramElement, Concept referencedConcept, String proposedName) {
-        Element element = paramElement;
-
-        // Go up on tree until you find class element.
-        while (element != null && !element.getKind().isClass()) {
-            element = element.getEnclosingElement();
-        }
-
-        // Class element found.
-        if (element != null) {
-            for (Element elem : element.getEnclosedElements()) {
-                if (elem.getKind().isField()) {
-                    VariableElement fieldElement = (VariableElement) elem;
-                    Type fieldType = getType(fieldElement.asType());
-                    if (fieldType instanceof yajco.model.type.ReferenceType) {
-                        yajco.model.type.ReferenceType referenceType = (yajco.model.type.ReferenceType) fieldType;
-                        if (referenceType.getConcept().equals(referencedConcept)) {
-                            if (!proposedName.isEmpty() && !fieldElement.getSimpleName().toString().equals(proposedName)) {
-                                continue;
-                            }
-                            return new Property(fieldElement.getSimpleName().toString(), referenceType, fieldElement);
-                        }
-                    }
-                }
-            }
-        }
-        return null;
-    }
-
-    /**
-     * Finds YAJCo model type of parameter.
-     *
-     * @param type Element type.
-     * @return YAJCo model type of parameter.
-     */
-    private Type getType(TypeMirror type) {
-        if (type.getKind() == TypeKind.ARRAY) {
-            return new yajco.model.type.ArrayType(getSimpleType(((ArrayType) type).getComponentType()));
-        } else if (isSpecifiedClassType(type, List.class)) {
-            return getSpecifiedYajcoComponentType(type, ListType.class);
-        } else if (isSpecifiedClassType(type, Set.class)) {
-            return getSpecifiedYajcoComponentType(type, SetType.class);
-        } else if (isSpecifiedClassType(type, Optional.class)) {
-            return getSpecifiedYajcoComponentType(type, OptionalType.class);
-        } else {
-            return getSimpleType(type);
-        }
-    }
-
-    /**
-     * Finds YAJCo component type of element.
-     *
-     * @param type Type of language model element.
-     * @param yajcoType YAJCo model type.
-     * @param <T>
-     * @return YAJCo component type of element.
-     */
-    private <T extends ComponentType> T getSpecifiedYajcoComponentType(TypeMirror type, Class<T> yajcoType) {
-        if (type.getKind() != TypeKind.DECLARED) {
-            throw new GeneratorException("Type " + type.toString() + " is not class or interface");
-        }
-
-        System.out.println("************************ " + type.getKind());
-
-        List<? extends TypeMirror> types = ((DeclaredType) type).getTypeArguments();
-
-        if (types.isEmpty()) {
-            throw new GeneratorException("Not specified type for " + type.toString() + ", please use generics to specify inner type.");
-        } else {
-            try {
-                Constructor constructor = yajcoType.getConstructor(Type.class);
-                if (processingEnv.getTypeUtils().asElement(type).toString().equals(Optional.class.getName())) {
-                    // Component type as Optional. For example Optional<String[]>
-                    return (T) (constructor.newInstance(getType(types.get(types.size() - 1))));
-                }
-                return (T) constructor.newInstance(getSimpleType(types.get(types.size() - 1)));
-            } catch (NoSuchMethodException ex) {
-                throw new GeneratorException("Cannot find constructor for " + yajcoType.getName() + " with only " + Type.class.getName() + " paramater!", ex);
-            } catch (Exception ex) {
-                throw new GeneratorException("Cannot create new object (" + yajcoType.getName() + ") needed for type " + type.toString(), ex);
-            }
-        }
-    }
-
-    private boolean isSpecifiedClassType(TypeMirror type, Class clazz) {
-        TypeElement referencedTypeElement = (TypeElement) processingEnv.getTypeUtils().asElement(type);
-        return clazz != null && referencedTypeElement != null
-                && referencedTypeElement.getQualifiedName().toString().equals(clazz.getName());
-    }
-
-    /**
-     * Finds YAJCo model type of argument.
-     *
-     * @param type Type of language model element.
-     * @return YAJCo model type of argument.
-     */
-    private Type getSimpleType(TypeMirror type) {
-        if (type.getKind().isPrimitive()) {
-            PrimitiveTypeConst primTypeConst = PrimitiveTypeConst.INTEGER;
-            switch (type.getKind()) {
-                case BOOLEAN:
-                    primTypeConst = yajco.model.type.PrimitiveTypeConst.BOOLEAN;
-                    break;
-                case BYTE:
-                case SHORT:
-                case INT:
-                case LONG:
-                    primTypeConst = yajco.model.type.PrimitiveTypeConst.INTEGER;
-                    break;
-                case FLOAT:
-                case DOUBLE:
-                    primTypeConst = yajco.model.type.PrimitiveTypeConst.REAL;
-                    break;
-            }
-            return new yajco.model.type.PrimitiveType(primTypeConst, type);
-        } else if (type.toString().equals(String.class.getName())) {
-            return new yajco.model.type.PrimitiveType(PrimitiveTypeConst.STRING, type);
-        } else if (type.toString().equals(Boolean.class.getName())) {
-            return new yajco.model.type.PrimitiveType(PrimitiveTypeConst.BOOLEAN, type);
-        } else if (type.toString().equals(Byte.class.getName())
-                || type.toString().equals(Short.class.getName())
-                || type.toString().equals(Integer.class.getName())
-                || type.toString().equals(Long.class.getName())) {
-            return new yajco.model.type.PrimitiveType(PrimitiveTypeConst.INTEGER, type);
-        } else if (type.toString().equals(Float.class.getName()) || type.toString().equals(Double.class.getName())) {
-            return new yajco.model.type.PrimitiveType(PrimitiveTypeConst.REAL, type);
-        } else if (type.getKind() == TypeKind.DECLARED) {
-            TypeElement referencedTypeElement = (TypeElement) processingEnv.getTypeUtils().asElement(type);
-            System.out.println("getSimpleType(): referencedTypeElement: " + referencedTypeElement);
-            if (referencedTypeElement != null && isKnownClass(referencedTypeElement)) {
-                return new yajco.model.type.ReferenceType(processTypeElement(referencedTypeElement), referencedTypeElement);
-            }
-        }
-        throw new GeneratorException("Unsupported simple type " + type + " [" + type.getKind() + "]");
-    }
-
-//    private yajco.model.pattern.impl.Range getRange(VariableElement paramElement, TypeMirror type) {
-//        yajco.annotation.Range range = paramElement.getAnnotation(yajco.annotation.Range.class);
-//        if (type.getKind() == TypeKind.ARRAY) {
-//            if (range != null) {
-//                return new yajco.model.pattern.impl.Range(range.minOccurs(), range.maxOccurs());
-//            }
-//        } else {
-//            if (range != null) {
-//                throw new GeneratorException("@Range should be applied only on array or list  type " + paramElement);
-//            }
-//        }
-//        return null;
-//    }
-
-    /**
-     * Finds all constructors nad factory methods in language model class.
-     *
-     * @param classElement Language model class.
-     * @return Set of executable elements (constructors and factory methods).
-     */
-    private Set<ExecutableElement> getConstructorsAndFactoryMethods(TypeElement classElement) {
-        Set<ExecutableElement> constructors = new HashSet<>();
-        for (Element element : processingEnv.getElementUtils().getAllMembers(classElement)) {
-            boolean isConstructor = isConstructor(element);
-            boolean isFactoryMethod = isFactoryMethod(element);
-
-            if (isConstructor || isFactoryMethod) {
-                constructors.add((ExecutableElement) element);
-            }
-        }
-
-        return constructors;
-    }
-
-    /**
-     * Checks if language model element is constructor.
-     *
-     * @param element Language model element.
-     * @return If element is constructor.
-     */
-    private boolean isConstructor(Element element) {
-        return element.getKind() == ElementKind.CONSTRUCTOR && element.getModifiers().contains(Modifier.PUBLIC)
-                && element.getAnnotation(Exclude.class) == null;
-    }
-
-    /**
-     * Checks if language model element is factory method.
-     *
-     * @param element Language model element.
-     * @return If element is factory method.
-     */
-    private boolean isFactoryMethod(Element element) {
-        return element.getKind() == ElementKind.METHOD && element.getModifiers().contains(Modifier.PUBLIC)
-                && element.getAnnotation(FactoryMethod.class) != null && element.getAnnotation(Exclude.class) == null;
-    }
-
-    /**
-     * Finds if element is already known class.
-     *
-     * @param element Language model element
-     * @return If element is already known class.
-     */
-    private boolean isKnownClass(Element element) {
-        if (element.getKind().isClass() || element.getKind().isInterface()) {
-            if (language.getConcept(((TypeElement) element).getQualifiedName().toString()) != null) {
-                return true;
-            }
-            for (Element elem : roundEnv.getRootElements()) {
-                if ((elem.getKind().isClass() || elem.getKind().isInterface()) && elem.equals(element)) {
-                    return true;
-                }
-            }
-        }
-        return false;
-    }
-
-    /**
-     * Returns the set of direct subtypes of the passes element.
-     *
-     * @param typeElement type element
-     * @return set of direct subtypes of the element.
-     */
-    private Set<TypeElement> getDirectSubtypes(TypeElement typeElement) {
-        Set<TypeElement> subclassElements = new HashSet<>();
-        for (Element element : roundEnv.getRootElements()) {
-            if (isDirectSubtype(typeElement, element)) {
-                subclassElements.add((TypeElement) element);
-            }
-        }
-
-        return subclassElements;
-    }
-
-    /**
-     * Returns true if superElement is the direct super class of the element.
-     * Otherwise returns false.
-     *
-     * @param superElement supertype
-     * @param element element
-     * @return true if superElement is the direct super class of the element.
-     */
-    private boolean isDirectSubtype(TypeElement superElement, Element element) {
-        Exclude excludeAnnotation = element.getAnnotation(Exclude.class);
-        int excludeAnnotationsLength = 0;
-        try {
-            if (excludeAnnotation != null) {
-                excludeAnnotation.value();
-            }
-        } catch (MirroredTypesException e) {
-            excludeAnnotationsLength = e.getTypeMirrors().size();
-        }
-        if (excludeAnnotation == null || excludeAnnotationsLength > 0) {
-            if (element.getKind().isClass() || element.getKind().isInterface()) {
-                TypeMirror superType = superElement.asType();
-                TypeElement typeElement = (TypeElement) element;
-                // Test superclass.
-                if (processingEnv.getTypeUtils().isSameType(typeElement.getSuperclass(), superType)) {
-                    return true;
-                }
-                // Test interfaces.
-                for (TypeMirror type : typeElement.getInterfaces()) {
-                    if (processingEnv.getTypeUtils().isSameType(type, superType)) {
-                        return true;
-                    }
-                }
-            }
-        }
-        return false;
-    }
-
-    private void addTokenParts(Notation notation, String[] values) {
-        for (String value : values) {
-            notation.addPart(new TokenPart(value));
-        }
-    }
-
-    //TOTO je klucove pre otvorenost procesora, kopiruje vzor uvedeny v anotacii do modelu
-    //TODO - navrhujem doplnit kontrolu podla typu vzoru
-    /**
-     * Finds if language model elements annotation is annotated with @MapsTo annotations.
-     *
-     * @param element Language model element.
-     * @param <T>
-     * @return If elements annotation contains annotated with @MapsTo annotations.
-     */
-    private <T extends Pattern> boolean hasPatternAnnotations(Element element) {
-        for (AnnotationMirror am : element.getAnnotationMirrors()) {
-            Element annotationElement = processingEnv.getTypeUtils().asElement(am.getAnnotationType());
-            MapsTo mapsTo = annotationElement.getAnnotation(MapsTo.class);
-            if (mapsTo != null) {
-                return true;
-            }
-        }
-        return false;
-    }
-
-    /**
-     * Adds patterns from annotations to language.
-     *
-     * @param element Language model element.
-     * @param patternSupport Language concept.
-     * @param <T>
-     */
-    private <T extends Pattern> void addPatternsFromAnnotations(Element element, PatternSupport<T> patternSupport) {
-        for (AnnotationMirror am : element.getAnnotationMirrors()) {
-            Element annotationElement = processingEnv.getTypeUtils().asElement(am.getAnnotationType());
-            MapsTo mapsTo = annotationElement.getAnnotation(MapsTo.class);
-            if (mapsTo != null) {
-                System.out.println("Processing annotation pattern: " + am);
-                String mapsToClass = mapsTo.value();
-                //String mapsToClass = null;
-//                try {
-//                    mapsTo.value();
-//                } catch (MirroredTypeException e) {
-//                    mapsToClass = e.getTypeMirror().toString();
-//                }
-
-                patternSupport.addPattern((T) createObjectFromAnnotation(mapsToClass, am));
-            }
-        }
-    }
-
-    /**
-     * Creates object from annotation.
-     *
-     * @param mapsToClass Class that reflects annotation function.
-     * @param am Annotation
-     * @return Pattern
-     */
-    private Pattern createObjectFromAnnotation(String mapsToClass, AnnotationMirror am) {
-        try {
-            Class<? extends Pattern> clazz = (Class<? extends Pattern>) Class.forName(mapsToClass);
-            Pattern pattern = clazz.newInstance();
-            // Copy from annotation into created object, according to the same names of annotation property and field.
-            Map<? extends ExecutableElement, ? extends AnnotationValue> values = processingEnv.getElementUtils().getElementValuesWithDefaults(am);
-            for (Map.Entry<? extends ExecutableElement, ? extends AnnotationValue> entry : values.entrySet()) {
-                String name = entry.getKey().getSimpleName().toString();
-                // For conversion see javax.​lang.​model.​element.​AnnotationValue
-                // TODO: Does not convert: arrays, annotation and classes
-                Object value = entry.getValue().getValue();
-                System.out.println("  " + name + " = " + value);
-                if (value instanceof VariableElement) {  // Enum value
-                    VariableElement enumField = (VariableElement) value;
-                    value = Enum.valueOf((Class<? extends Enum>) Class.forName(enumField.asType().toString()), enumField.getSimpleName().toString());
-                }
-                Field field = clazz.getDeclaredField(name);
-                field.setAccessible(true);
-                System.out.println(" >" + name + " = " + field.get(pattern));
-                field.set(pattern, value);
-                System.out.println(" >>" + name + " = " + field.get(pattern));
-            }
-            return pattern;
-        } catch (Exception e) {
-            // TODO: upravit vypis
-            throw new GeneratorException("Cannot instantiate class for @MapsTo, class " + mapsToClass, e);
         }
     }
 
@@ -1534,43 +225,4 @@ public class AnnotationProcessor extends AbstractProcessor {
                     CompilerGenerator.class.getName() + " in your classpath. (see java.util.ServiceLoader javadoc for details)");
         }
     }
-
-
-    /**
-     * Processes direct subclasses of language model element.
-     *
-     * @param typeElement Language model element.
-     * @param concept Language concept representing language model element.
-     */
-    private void processDirectSubclasses(TypeElement typeElement, Concept concept) {
-        System.out.print("DirectSubtypes of " + typeElement.getSimpleName() + " are: ");
-        for (TypeElement subtypeElement : getDirectSubtypes(typeElement)) {
-            System.out.print(subtypeElement.getSimpleName() + "  ");
-            processTypeElement(subtypeElement, concept);
-        }
-        System.out.println();
-    }
-
-    /**
-     * Adds new items to original list according to overwrite flag.
-     *
-     * @param originalList Original list.
-     * @param newItems List of new items.
-     * @param overwrite Overwrite flag.
-     * @param <T>
-     */
-    private <T> void addToListAsSet(List<T> originalList, List<T> newItems, boolean overwrite) {
-        for (T item : newItems) {
-            if (originalList.contains(item)) {
-                if (overwrite) {
-                    // dolezite je to, aby item.equals fungoval spravne
-                    originalList.remove(item); // odstrani povodny
-                    originalList.add(item); // vlozi novy
-                }
-            } else {
-                originalList.add(item);
-            }
-        }
-    }
-
 }

--- a/yajco-annotation-processor/src/main/java/yajco/annotation/processor/AnnotationProcessor.java
+++ b/yajco-annotation-processor/src/main/java/yajco/annotation/processor/AnnotationProcessor.java
@@ -19,6 +19,7 @@ import javax.lang.model.element.Element;
 import javax.lang.model.element.TypeElement;
 import javax.lang.model.type.MirroredTypesException;
 import javax.lang.model.type.TypeMirror;
+import javax.tools.Diagnostic;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.PrintWriter;
@@ -88,6 +89,9 @@ public class AnnotationProcessor extends AbstractProcessor {
                 Set<? extends Element> elements = roundEnv.getElementsAnnotatedWith(yajco.annotation.config.Parser.class);
                 if (elements.isEmpty()) {
                     return false;
+                }
+                if (elements.size() > 1) {
+                    processingEnv.getMessager().printMessage(Diagnostic.Kind.WARNING, "More than one @Parser annotation found. Multiple parsers are not fully supported.");
                 }
 
                 // Process each @Parser annotation

--- a/yajco-annotation-processor/src/main/java/yajco/annotation/processor/ConceptRegistry.java
+++ b/yajco-annotation-processor/src/main/java/yajco/annotation/processor/ConceptRegistry.java
@@ -1,0 +1,192 @@
+package yajco.annotation.processor;
+
+import org.checkerframework.checker.nullness.qual.Nullable;
+import yajco.annotation.Exclude;
+import yajco.model.Concept;
+import yajco.model.Language;
+
+import javax.lang.model.element.Element;
+import javax.lang.model.element.TypeElement;
+import javax.lang.model.type.MirroredTypesException;
+import javax.lang.model.type.TypeMirror;
+import javax.lang.model.util.Types;
+import java.util.Collection;
+import java.util.HashSet;
+import java.util.LinkedHashSet;
+import java.util.Set;
+
+/**
+ * Central registry for language concepts discovered during annotation processing.
+ * The registry is intentionally stateful for a single parser/model-building run and should
+ * be created per language instance.
+ */
+public class ConceptRegistry {
+    private final Language language;
+    private final Set<? extends Element> rootElements;
+    private final Set<String> excludes;
+    private final Types typeUtils;
+
+    /**
+     * Set for concepts imported from previous JARs and needed for full analysis.
+     */
+    private final Set<Concept> conceptsToProcess = new HashSet<>();
+
+    public ConceptRegistry(Language language, Set<? extends Element> rootElements, Set<String> excludes, Types typeUtils) {
+        this.language = language;
+        this.rootElements = rootElements;
+        this.excludes = excludes;
+        this.typeUtils = typeUtils;
+    }
+
+    /**
+     * Registers concepts imported from external language definitions.
+     * Imported concepts are added to the current language and marked for potential reprocessing.
+     */
+    public void registerImportedConcepts(Collection<Concept> imported) {
+        conceptsToProcess.addAll(imported);
+        language.getConcepts().addAll(imported);
+    }
+
+    /**
+     * Returns an existing concept for the given type or creates a new one when missing.
+     * Optionally assign a parent concept.
+     *
+     * @return resolved or newly created concept, or {@code null} when the type is excluded
+     */
+    public @Nullable Concept getOrCreate(TypeElement typeElement, @Nullable Concept parent) {
+        if (shouldSkip(typeElement)) {
+            return null;
+        }
+
+        String name = normalizedName(typeElement);
+        Concept concept = language.getConcept(name);
+        if (concept == null) {
+            concept = new Concept(name, typeElement);
+            language.addConcept(concept);
+        }
+
+        if (parent != null) {
+            concept.setParent(parent);
+        }
+
+        return concept;
+    }
+
+    /**
+     * Returns whether the given type element is excluded from processing.
+     */
+    public boolean shouldSkip(TypeElement typeElement) {
+        return excludes.contains(typeElement.getQualifiedName().toString());
+    }
+
+    /**
+     * Finds direct subtypes of the given supertype among round root elements.
+     */
+    public Iterable<TypeElement> directSubtypesOf(TypeElement superType) {
+        Set<TypeElement> result = new LinkedHashSet<>();
+        for (Element element : rootElements) {
+            if (isDirectSubtype(superType, element)) {
+                result.add((TypeElement) element);
+            }
+        }
+        return result;
+    }
+
+    /**
+     * Resolves a concept only if the type is known in the current processing scope.
+     *
+     * @return matching concept, or {@code null} if the type is unknown or out of scope
+     */
+    public @Nullable Concept resolveKnown(TypeElement typeElement) {
+        if (typeElement == null || !isKnownClass(typeElement)) {
+            return null;
+        }
+
+        Concept byNormalized = language.getConcept(normalizedName(typeElement));
+        if (byNormalized != null) {
+            return byNormalized;
+        }
+
+        return language.getConcept(typeElement.getQualifiedName().toString());
+    }
+
+    /**
+     * Marks an imported concept as consumed (already reprocessed) in this run.
+     *
+     * @return {@code true} if the concept was pending and is now consumed
+     */
+    public boolean consumeImportedConcept(Concept concept) {
+        return conceptsToProcess.remove(concept);
+    }
+
+    /**
+     * Returns whether the element represents a class/interface known to the current language
+     * or to the current compilation round root set.
+     */
+    public boolean isKnownClass(Element element) {
+        if (!(element.getKind().isClass() || element.getKind().isInterface())) {
+            return false;
+        }
+
+        TypeElement typeElement = (TypeElement) element;
+        if (language.getConcept(typeElement.getQualifiedName().toString()) != null) {
+            return true;
+        }
+        if (language.getConcept(normalizedName(typeElement)) != null) {
+            return true;
+        }
+
+        for (Element elem : rootElements) {
+            if ((elem.getKind().isClass() || elem.getKind().isInterface()) && elem.equals(element)) {
+                return true;
+            }
+        }
+        return false;
+    }
+
+    private String normalizedName(TypeElement typeElement) {
+        String name = typeElement.getQualifiedName().toString();
+        if (language.getName() != null && !language.getName().isEmpty() && name.startsWith(language.getName() + ".")) {
+            return name.substring(language.getName().length() + 1); // +1 because of dot after package name '.'
+        }
+        return name;
+    }
+
+    /**
+     * Returns true if superElement is the direct super class of the element.
+     * Otherwise, returns false.
+     *
+     * @param superElement supertype
+     * @param element element
+     * @return true if superElement is the direct super class of the element.
+     */
+    private boolean isDirectSubtype(TypeElement superElement, Element element) {
+        Exclude excludeAnnotation = element.getAnnotation(Exclude.class);
+        int excludeAnnotationsLength = 0;
+        try {
+            if (excludeAnnotation != null) {
+                excludeAnnotation.value();
+            }
+        } catch (MirroredTypesException e) {
+            excludeAnnotationsLength = e.getTypeMirrors().size();
+        }
+
+        if (excludeAnnotation == null || excludeAnnotationsLength > 0) {
+            if (element.getKind().isClass() || element.getKind().isInterface()) {
+                TypeMirror superType = superElement.asType();
+                TypeElement typeElement = (TypeElement) element;
+                // Test superclass.
+                if (typeUtils.isSameType(typeElement.getSuperclass(), superType)) {
+                    return true;
+                }
+                // Test interfaces.
+                for (TypeMirror type : typeElement.getInterfaces()) {
+                    if (typeUtils.isSameType(type, superType)) {
+                        return true;
+                    }
+                }
+            }
+        }
+        return false;
+    }
+}

--- a/yajco-annotation-processor/src/main/java/yajco/annotation/processor/ConceptRegistry.java
+++ b/yajco-annotation-processor/src/main/java/yajco/annotation/processor/ConceptRegistry.java
@@ -137,8 +137,11 @@ public class ConceptRegistry {
         }
 
         for (Element elem : rootElements) {
-            if ((elem.getKind().isClass() || elem.getKind().isInterface()) && elem.equals(element)) {
-                return true;
+            if (elem.getKind().isClass() || elem.getKind().isInterface()) {
+                TypeElement rootTypeElement = (TypeElement) elem;
+                if (typeUtils.isSameType(rootTypeElement.asType(), typeElement.asType())) {
+                    return true;
+                }
             }
         }
         return false;

--- a/yajco-annotation-processor/src/main/java/yajco/annotation/processor/LanguageModelBuilder.java
+++ b/yajco-annotation-processor/src/main/java/yajco/annotation/processor/LanguageModelBuilder.java
@@ -11,14 +11,15 @@ import yajco.model.*;
 import yajco.model.pattern.Pattern;
 import yajco.model.pattern.PatternSupport;
 import yajco.model.pattern.impl.Factory;
-import yajco.model.type.*;
+import yajco.model.type.ListType;
+import yajco.model.type.OptionalType;
+import yajco.model.type.PrimitiveTypeConst;
+import yajco.model.type.Type;
 import yajco.model.utilities.XMLLanguageFormatHelper;
 
 import javax.annotation.processing.ProcessingEnvironment;
 import javax.lang.model.element.*;
 import javax.lang.model.type.*;
-import javax.lang.model.type.ArrayType;
-import java.lang.reflect.Constructor;
 import java.lang.reflect.Field;
 import java.util.*;
 import java.util.Optional;
@@ -28,7 +29,7 @@ public class LanguageModelBuilder {
     private ProcessingEnvironment processingEnv;
     private final Set<? extends Element> rootElements;
     private Set<String> excludes = new HashSet<>();
-
+    private final TypeResolver typeResolver;
     /**
      * Builded language.
      */
@@ -52,6 +53,7 @@ public class LanguageModelBuilder {
         this.processingEnv = processingEnv;
         this.rootElements = rootElements;
         this.excludes = excludes;
+        this.typeResolver = new TypeResolver(processingEnv.getTypeUtils(), this::resolveReferenceConcept);
     }
 
     public Language createLanguageModel(Element parserAnnotationElement, Parser parserAnnotation) {
@@ -85,6 +87,14 @@ public class LanguageModelBuilder {
         language.setSettings(LanguageSetting.convertToLanguageSetting(properties));
 
         return language;
+    }
+
+    public Concept resolveReferenceConcept(TypeElement typeElement) {
+        if (typeElement != null && isKnownClass(typeElement)) {
+            return processTypeElement(typeElement);
+        } else {
+            return null;
+        }
     }
 
     private @NonNull TypeElement extractMainElement(Element parserAnnotationElement, Parser parserAnnotation) {
@@ -559,7 +569,7 @@ public class LanguageModelBuilder {
                 processParameter(concept, notation, paramElement);
                 excludedCount++;
                 cantBeUnordered = unorderedCount > 0 && excludedCount > 0;
-            } else if (getType(paramElement.asType()) instanceof OptionalType)  {
+            } else if (typeResolver.getType(paramElement.asType()) instanceof OptionalType)  {
                 UnorderedParamPart unorderedParamPart = new UnorderedParamPart(null);
                 OptionalPart optionalPart = (OptionalPart) processCompoundParameter(concept, paramElement, new OptionalPart(null));
                 unorderedParamPart.addPart(optionalPart);
@@ -599,7 +609,7 @@ public class LanguageModelBuilder {
                 processParameter(concept, notation, paramElement);
             } else {
                 // Parameter should be a collection type (List or Array)
-                Type paramType = getType(paramElement.asType());
+                Type paramType = typeResolver.getType(paramElement.asType());
 
                 if (!(paramType instanceof ListType || paramType instanceof ArrayType)) {
                     throw new GeneratorException(
@@ -646,7 +656,10 @@ public class LanguageModelBuilder {
 
                 // Add only fields with property patterns (PropertyPattern).
                 if (hasPatternAnnotations(fieldElement)) {
-                    Property property = new Property(fieldElement.getSimpleName().toString(), getType(fieldElement.asType()), fieldElement);
+                    Property property = new Property(
+                        fieldElement.getSimpleName().toString(),
+                        typeResolver.getType(fieldElement.asType()),
+                        fieldElement);
                     addPatternsFromAnnotations(fieldElement, property);
                     concept.addProperty(property);
                 }
@@ -682,7 +695,7 @@ public class LanguageModelBuilder {
      * @param paramElement Parameter of constructor or factory method.
      */
     private void processParameter(Concept concept, Notation notation, VariableElement paramElement) {
-        Type type = getType(paramElement.asType());
+        Type type = typeResolver.getType(paramElement.asType());
         yajco.annotation.Flag flagAnnotation = paramElement.getAnnotation(yajco.annotation.Flag.class);
 
         // Handle @Flag annotation on boolean parameters
@@ -732,7 +745,7 @@ public class LanguageModelBuilder {
 
             if (references != null) { // @References annotation.
                 //TODO: zatial nie je podpora pre polia referencii, treba to vsak doriesit
-                type = getSimpleType(typeMirror);
+                type = typeResolver.getSimpleType(typeMirror);
                 LocalVariablePart localVariablePart = new LocalVariablePart(paramName, type, paramElement);
                 notation.addPart(localVariablePart);
 
@@ -740,7 +753,7 @@ public class LanguageModelBuilder {
             } else { // Property reference.
                 Property property = concept.getProperty(paramName);
                 if (property == null) {
-                    property = new Property(paramName, getType(typeMirror), null);
+                    property = new Property(paramName, typeResolver.getType(typeMirror), null);
                     concept.addProperty(property);
                 }
 
@@ -812,9 +825,9 @@ public class LanguageModelBuilder {
             Type type;
             List<? extends TypeMirror> types = ((DeclaredType) typeMirror).getTypeArguments();
             if (processingEnv.getTypeUtils().asElement(typeMirror).toString().equals(Optional.class.getName())) {
-                type = getSimpleType(types.get(types.size() - 1));
+                type = typeResolver.getSimpleType(types.get(types.size() - 1));
             } else {
-                type = getSimpleType(typeMirror);
+                type = typeResolver.getSimpleType(typeMirror);
             }
             LocalVariablePart localVariablePart = new LocalVariablePart(paramName, type, paramElement);
             notationPart.addPart(localVariablePart);
@@ -822,7 +835,7 @@ public class LanguageModelBuilder {
         } else { // Property reference.
             Property property = concept.getProperty(paramName);
             if (property == null) {
-                property = new Property(paramName, getType(typeMirror), null);
+                property = new Property(paramName, typeResolver.getType(typeMirror), null);
                 concept.addProperty(property);
             }
 
@@ -997,7 +1010,7 @@ public class LanguageModelBuilder {
             for (Element elem : element.getEnclosedElements()) {
                 if (elem.getKind().isField()) {
                     VariableElement fieldElement = (VariableElement) elem;
-                    Type fieldType = getType(fieldElement.asType());
+                    Type fieldType = typeResolver.getType(fieldElement.asType());
                     if (fieldType instanceof yajco.model.type.ReferenceType) {
                         yajco.model.type.ReferenceType referenceType = (yajco.model.type.ReferenceType) fieldType;
                         if (referenceType.getConcept().equals(referencedConcept)) {
@@ -1011,113 +1024,6 @@ public class LanguageModelBuilder {
             }
         }
         return null;
-    }
-
-    /**
-     * Finds YAJCo model type of parameter.
-     *
-     * @param type Element type.
-     * @return YAJCo model type of parameter.
-     */
-    private Type getType(TypeMirror type) {
-        if (type.getKind() == TypeKind.ARRAY) {
-            return new yajco.model.type.ArrayType(getSimpleType(((ArrayType) type).getComponentType()));
-        } else if (isSpecifiedClassType(type, List.class)) {
-            return getSpecifiedYajcoComponentType(type, ListType.class);
-        } else if (isSpecifiedClassType(type, Set.class)) {
-            return getSpecifiedYajcoComponentType(type, SetType.class);
-        } else if (isSpecifiedClassType(type, Optional.class)) {
-            return getSpecifiedYajcoComponentType(type, OptionalType.class);
-        } else {
-            return getSimpleType(type);
-        }
-    }
-
-    /**
-     * Finds YAJCo component type of element.
-     *
-     * @param type Type of language model element.
-     * @param yajcoType YAJCo model type.
-     * @param <T>
-     * @return YAJCo component type of element.
-     */
-    private <T extends ComponentType> T getSpecifiedYajcoComponentType(TypeMirror type, Class<T> yajcoType) {
-        if (type.getKind() != TypeKind.DECLARED) {
-            throw new GeneratorException("Type " + type.toString() + " is not class or interface");
-        }
-
-        System.out.println("************************ " + type.getKind());
-
-        List<? extends TypeMirror> types = ((DeclaredType) type).getTypeArguments();
-
-        if (types.isEmpty()) {
-            throw new GeneratorException("Not specified type for " + type.toString() + ", please use generics to specify inner type.");
-        } else {
-            try {
-                Constructor constructor = yajcoType.getConstructor(Type.class);
-                if (processingEnv.getTypeUtils().asElement(type).toString().equals(Optional.class.getName())) {
-                    // Component type as Optional. For example Optional<String[]>
-                    return (T) (constructor.newInstance(getType(types.get(types.size() - 1))));
-                }
-                return (T) constructor.newInstance(getSimpleType(types.get(types.size() - 1)));
-            } catch (NoSuchMethodException ex) {
-                throw new GeneratorException("Cannot find constructor for " + yajcoType.getName() + " with only " + Type.class.getName() + " paramater!", ex);
-            } catch (Exception ex) {
-                throw new GeneratorException("Cannot create new object (" + yajcoType.getName() + ") needed for type " + type.toString(), ex);
-            }
-        }
-    }
-
-    private boolean isSpecifiedClassType(TypeMirror type, Class clazz) {
-        TypeElement referencedTypeElement = (TypeElement) processingEnv.getTypeUtils().asElement(type);
-        return clazz != null && referencedTypeElement != null
-               && referencedTypeElement.getQualifiedName().toString().equals(clazz.getName());
-    }
-
-    /**
-     * Finds YAJCo model type of argument.
-     *
-     * @param type Type of language model element.
-     * @return YAJCo model type of argument.
-     */
-    private Type getSimpleType(TypeMirror type) {
-        if (type.getKind().isPrimitive()) {
-            PrimitiveTypeConst primTypeConst = PrimitiveTypeConst.INTEGER;
-            switch (type.getKind()) {
-                case BOOLEAN:
-                    primTypeConst = yajco.model.type.PrimitiveTypeConst.BOOLEAN;
-                    break;
-                case BYTE:
-                case SHORT:
-                case INT:
-                case LONG:
-                    primTypeConst = yajco.model.type.PrimitiveTypeConst.INTEGER;
-                    break;
-                case FLOAT:
-                case DOUBLE:
-                    primTypeConst = yajco.model.type.PrimitiveTypeConst.REAL;
-                    break;
-            }
-            return new yajco.model.type.PrimitiveType(primTypeConst, type);
-        } else if (type.toString().equals(String.class.getName())) {
-            return new yajco.model.type.PrimitiveType(PrimitiveTypeConst.STRING, type);
-        } else if (type.toString().equals(Boolean.class.getName())) {
-            return new yajco.model.type.PrimitiveType(PrimitiveTypeConst.BOOLEAN, type);
-        } else if (type.toString().equals(Byte.class.getName())
-                   || type.toString().equals(Short.class.getName())
-                   || type.toString().equals(Integer.class.getName())
-                   || type.toString().equals(Long.class.getName())) {
-            return new yajco.model.type.PrimitiveType(PrimitiveTypeConst.INTEGER, type);
-        } else if (type.toString().equals(Float.class.getName()) || type.toString().equals(Double.class.getName())) {
-            return new yajco.model.type.PrimitiveType(PrimitiveTypeConst.REAL, type);
-        } else if (type.getKind() == TypeKind.DECLARED) {
-            TypeElement referencedTypeElement = (TypeElement) processingEnv.getTypeUtils().asElement(type);
-            System.out.println("getSimpleType(): referencedTypeElement: " + referencedTypeElement);
-            if (referencedTypeElement != null && isKnownClass(referencedTypeElement)) {
-                return new yajco.model.type.ReferenceType(processTypeElement(referencedTypeElement), referencedTypeElement);
-            }
-        }
-        throw new GeneratorException("Unsupported simple type " + type + " [" + type.getKind() + "]");
     }
 
 //    private yajco.model.pattern.impl.Range getRange(VariableElement paramElement, TypeMirror type) {

--- a/yajco-annotation-processor/src/main/java/yajco/annotation/processor/LanguageModelBuilder.java
+++ b/yajco-annotation-processor/src/main/java/yajco/annotation/processor/LanguageModelBuilder.java
@@ -1,0 +1,1376 @@
+package yajco.annotation.processor;
+
+import org.checkerframework.checker.nullness.qual.NonNull;
+import yajco.annotation.*;
+import yajco.annotation.config.Option;
+import yajco.annotation.config.Parser;
+import yajco.annotation.config.Skip;
+import yajco.annotation.reference.References;
+import yajco.generator.GeneratorException;
+import yajco.model.*;
+import yajco.model.pattern.Pattern;
+import yajco.model.pattern.PatternSupport;
+import yajco.model.pattern.impl.Factory;
+import yajco.model.type.*;
+import yajco.model.utilities.XMLLanguageFormatHelper;
+
+import javax.annotation.processing.ProcessingEnvironment;
+import javax.lang.model.element.*;
+import javax.lang.model.type.*;
+import javax.lang.model.type.ArrayType;
+import java.lang.reflect.Constructor;
+import java.lang.reflect.Field;
+import java.util.*;
+import java.util.Optional;
+
+public class LanguageModelBuilder {
+    private Properties properties;
+    private ProcessingEnvironment processingEnv;
+    private final Set<? extends Element> rootElements;
+    private Set<String> excludes = new HashSet<>();
+
+    /**
+     * Builded language.
+     */
+    private Language language;
+
+    /**
+     * Set for concepts imported from previous JARs and needed for full analysis.
+     */
+    private Set<Concept> conceptsToProcess = new HashSet<>();
+
+    /**
+     * Used for creation of string tokens defined by @StringToken annotation.
+     */
+    private int stringTokenId = 1;
+    private static final String DEFAULT_STRING_TOKEN_NAME = "STRING_TOKEN";
+    private static final String IDENTIFIER_TOKEN_NAME = "IDENTIFIER";
+    private static final String IDENTIFIER_TOKEN_REGEXP = "[a-zA-Z_][a-zA-Z0-9_]*";
+
+    public LanguageModelBuilder(Properties properties, ProcessingEnvironment processingEnv, Set<? extends Element> rootElements, Set<String> excludes) {
+        this.properties = properties;
+        this.processingEnv = processingEnv;
+        this.rootElements = rootElements;
+        this.excludes = excludes;
+    }
+
+    public Language createLanguageModel(Element parserAnnotationElement, Parser parserAnnotation) {
+        this.extractOptionsFromParserAnnotation(parserAnnotation);
+        this.extractLanguageAnnotation(parserAnnotationElement);
+
+        // Extract the main element, package or type can be annotated with @Parser.
+        TypeElement mainElement = extractMainElement(parserAnnotationElement, parserAnnotation);
+
+        // Create language.
+        language = new Language(mainElement);
+        // Add main package name == language name.
+        String mainElementName = mainElement.getQualifiedName().toString();
+        String languageName = mainElementName.substring(0, mainElementName.lastIndexOf('.'));
+        System.out.println("---- mainElementName: " + mainElementName + " == languageName: " + languageName);
+        if (!languageName.isEmpty()) {
+            language.setName(languageName);
+        }
+
+        // Add language concepts from included JARs.
+        addLanguageConceptsFromIncludedJARs();
+
+        // Start processing with the main element.
+        System.out.println(" ? mainElement ? : " + mainElement);
+        processTypeElement(mainElement);
+
+        // Add tokens and skips into language.
+        addTokensAndSkipsIntoLanguage(parserAnnotation, parserAnnotationElement);
+
+        // Convert properties to language settings.
+        language.setSettings(LanguageSetting.convertToLanguageSetting(properties));
+
+        return language;
+    }
+
+    private @NonNull TypeElement extractMainElement(Element parserAnnotationElement, Parser parserAnnotation) {
+        ElementKind parserAnnotationElemKind = parserAnnotationElement.getKind();
+        TypeElement mainElement;
+        String mainElementName;
+        if (parserAnnotationElemKind == ElementKind.PACKAGE) {
+            mainElementName = parserAnnotation.mainNode();
+            if (mainElementName.indexOf('.') == -1) {
+                //TODO: Chyba v javac - ak nexistovala trieda tak ju vytvorilo ale nehlasilo null
+                // ak som zavolal pre "Expression" vratilo sice null ale potom hlasilo duplicate class
+                //mainElement = processingEnv.getElementUtils().getTypeElement(mainElementName);
+                //mozno treba niekde v tools nastavit aby negenerovalo po otazke triedu ak neexistuje,
+                //zda sa mi ze som to niekde videl v helpe
+                mainElementName = ((PackageElement) parserAnnotationElement).getQualifiedName() + "." + mainElementName;
+            }
+            mainElement = processingEnv.getElementUtils().getTypeElement(mainElementName);
+        } else if (parserAnnotationElemKind == ElementKind.CLASS || parserAnnotationElemKind == ElementKind.INTERFACE || parserAnnotationElemKind == ElementKind.ENUM) {
+            mainElement = (TypeElement) parserAnnotationElement;
+            mainElementName = mainElement.asType().toString();
+            properties.setProperty("yajco.mainNode", mainElementName);
+        } else {
+            System.err.println("@Parser annotation can't be used on [" + parserAnnotationElemKind.toString() + "]\n");
+            throw new GeneratorException("Annotation @Parser should annotate only package, class, interface or enum.");
+        }
+
+        if (mainElement == null) {
+            throw new GeneratorException("Main language concept not found '" + parserAnnotation.mainNode() + "'");
+        }
+        return mainElement;
+    }
+
+    /**
+     * Collects all options from @Parser annotation and store them to Properties object. Sets className and mainNode
+     * if they are defined in @Parser annotation.
+     *
+     * @param parserAnnotation @Parser annotation object.
+     */
+    private void extractOptionsFromParserAnnotation(Parser parserAnnotation) {
+        for (Option option : parserAnnotation.options()) {
+            properties.setProperty(option.name(), option.value());
+        }
+
+        if (!parserAnnotation.className().isEmpty()) {
+            properties.setProperty("yajco.className", parserAnnotation.className());
+        }
+        if (!parserAnnotation.mainNode().isEmpty()) {
+            properties.setProperty("yajco.mainNode", parserAnnotation.mainNode());
+        }
+    }
+
+    /**
+     * Extracts metadata from {@code @Language} annotation and stores it in properties.
+     * When {@code @Language} is present, IR generation is automatically enabled.
+     *
+     * @param element The element annotated with both @Parser and potentially @Language.
+     */
+    private void extractLanguageAnnotation(Element element) {
+        yajco.annotation.config.Language lang = element.getAnnotation(yajco.annotation.config.Language.class);
+        if (lang == null) {
+            return;
+        }
+
+        // Auto-enable IR generation when @Language is present
+        String tools = properties.getProperty("yajco.generateTools", "");
+        if (!tools.toLowerCase().contains("ir") && !tools.toLowerCase().contains("all")) {
+            properties.setProperty("yajco.generateTools",
+                tools.isEmpty() ? "ir" : tools + ",ir");
+        }
+
+        // Language name
+        if (!lang.name().isEmpty()) {
+            properties.setProperty("yajco.ir.languageName", lang.name());
+        }
+
+        // Description
+        if (!lang.description().isEmpty()) {
+            properties.setProperty("yajco.ir.description", lang.description());
+        }
+
+        // Version
+        if (!lang.version().isEmpty()) {
+            properties.setProperty("yajco.ir.version", lang.version());
+        }
+
+        // File extensions (joined as comma-separated string)
+        if (lang.fileExtensions().length > 0) {
+            properties.setProperty("yajco.ir.fileExtensions",
+                String.join(",", lang.fileExtensions()));
+        }
+
+        // Comment syntax — stored as explicit properties for the IR generator
+        if (!lang.lineComment().isEmpty()) {
+            properties.setProperty("yajco.ir.lineComment", lang.lineComment());
+        }
+        if (lang.blockComment().length == 2) {
+            properties.setProperty("yajco.ir.blockComment.start", lang.blockComment()[0]);
+            properties.setProperty("yajco.ir.blockComment.end", lang.blockComment()[1]);
+        }
+
+        // IR file name defaults to {languageName}.ir.json if not already set
+        if (!properties.containsKey("yajco.ir.file") && !lang.name().isEmpty()) {
+            properties.setProperty("yajco.ir.file", lang.name() + ".ir.json");
+        }
+    }
+
+    /**
+     * Generates skip rules from {@code @Language} comment syntax and adds them
+     * to the parser's skip list. This allows users to specify comment syntax once
+     * in {@code @Language} without needing a separate {@code @Skip} annotation.
+     *
+     * @param element The element annotated with @Language.
+     * @param existingSkips The skip list from @Parser to check for duplicates.
+     * @return Additional SkipDef entries to add to the language.
+     */
+    private List<SkipDef> buildCommentSkipsFromLanguage(Element element, List<SkipDef> existingSkips) {
+        yajco.annotation.config.Language lang = element.getAnnotation(yajco.annotation.config.Language.class);
+        if (lang == null) {
+            return Collections.emptyList();
+        }
+
+        // Collect existing skip patterns to avoid duplicates
+        Set<String> existingPatterns = new HashSet<>();
+        for (SkipDef skip : existingSkips) {
+            existingPatterns.add(skip.getRegexp());
+        }
+
+        List<SkipDef> commentSkips = new ArrayList<>();
+
+        // Line comment: prefix → prefix + ".*"
+        if (!lang.lineComment().isEmpty()) {
+            String pattern = escapeRegex(lang.lineComment()) + ".*";
+            if (!existingPatterns.contains(pattern)) {
+                commentSkips.add(new SkipDef(pattern));
+            }
+        }
+
+        // Block comment: [start, end] → start + "(?:(?!" + end + ")[\\s\\S])*" + end
+        if (lang.blockComment().length == 2) {
+            String start = escapeRegex(lang.blockComment()[0]);
+            String end = escapeRegex(lang.blockComment()[1]);
+            String pattern = start + "(?:(?!" + end + ")[\\s\\S])*" + end;
+            if (!existingPatterns.contains(pattern)) {
+                commentSkips.add(new SkipDef(pattern));
+            }
+        }
+
+        return commentSkips;
+    }
+
+    /**
+     * Loads language concepts, skips and tokens from languages included as JAR files.
+     */
+    private void addLanguageConceptsFromIncludedJARs() {
+        List<Language> includedLanguages = XMLLanguageFormatHelper.getAllLanguagesFromXML();
+        System.out.println("Loaded external language specifications: " + includedLanguages.size());
+        for (Language incLang : includedLanguages) {
+            System.out.print("Loaded from JAR: ");
+            for (Concept concept : incLang.getConcepts()) {
+                System.out.print(concept.getName() + ", ");
+            }
+            System.out.println();
+
+            addToListAsSet(language.getSkips(), incLang.getSkips(), true);
+            addToListAsSet(language.getTokens(), incLang.getTokens(), true);
+            conceptsToProcess.addAll(incLang.getConcepts());
+            language.getConcepts().addAll(incLang.getConcepts());
+        }
+    }
+
+    /**
+     * Adds tokens and skips defined in @Parser annotation into language.
+     * Also adds comment skip rules from @Language if present.
+     *
+     * @param parserAnnotation @Parser annotation object
+     * @param parserAnnotationElement The annotated element (for reading @Language)
+     */
+    private void addTokensAndSkipsIntoLanguage(Parser parserAnnotation, Element parserAnnotationElement) {
+        List<TokenDef> tokens = new ArrayList<>();
+        List<SkipDef> skips = new ArrayList<>();
+        for (yajco.annotation.config.TokenDef tokenDef : parserAnnotation.tokens()) {
+            tokens.add(new TokenDef(tokenDef.name(), tokenDef.regexp(), tokenDef));
+        }
+        for (Skip skip : parserAnnotation.skips()) {
+            String regexp = convertSkipToRegexp(skip);
+            skips.add(new SkipDef(regexp, skip));
+        }
+
+        // Add default white space for skips if empty.
+        if (skips.isEmpty()) {
+            skips.add(new SkipDef("\\s"));
+        }
+
+        // Add comment skip rules from @Language (avoids duplicate @Skip for comments)
+        List<SkipDef> commentSkips = buildCommentSkipsFromLanguage(parserAnnotationElement, skips);
+        skips.addAll(commentSkips);
+
+        addToListAsSet(language.getSkips(), skips, true);
+        addToListAsSet(language.getTokens(), tokens, true);
+    }
+
+    /**
+     * Converts @Skip annotation parameters into a regular expression.
+     * Supports syntactic sugar for whitespace and comment patterns.
+     *
+     * @param skip @Skip annotation object
+     * @return Regular expression string
+     */
+    private String convertSkipToRegexp(Skip skip) {
+        // If value is explicitly set, use it directly (highest priority)
+        if (!skip.value().isEmpty()) {
+            return skip.value();
+        }
+
+        // Handle whitespace flag
+        if (skip.whitespace()) {
+            return "\\s";
+        }
+
+        // Handle comment patterns with start and optional end
+        if (!skip.start().isEmpty()) {
+            String start = escapeRegex(skip.start());
+            if (!skip.end().isEmpty()) {
+                // Multi-line comment with explicit end: start...end
+                String end = escapeRegex(skip.end());
+                return start + "(?:(?!" + end + ")[\\s\\S])*" + end;
+            } else {
+                // Single-line comment: start until end of line
+                return start + ".*";
+            }
+        }
+
+        // If nothing is specified, return empty string (should not happen in practice)
+        return "";
+    }
+
+    /**
+     * Escapes special regex characters in a literal string.
+     *
+     * @param literal String to escape
+     * @return Escaped string safe for use in regex
+     */
+    private String escapeRegex(String literal) {
+        return literal.replaceAll("([\\\\.*+?^${}()|\\[\\]])", "\\\\$1");
+    }
+
+
+    /**
+     * Processes language model elements.
+     *
+     * @param typeElement Language model element to process.
+     * @return Processed language concept.
+     */
+    private Concept processTypeElement(TypeElement typeElement) {
+        return processTypeElement(typeElement, null);
+    }
+
+    /**
+     * Processes language model elements and creates unique language concepts for all of them.
+     *
+     * @param typeElement Language model element to process.
+     * @param superConcept Parent concept.
+     * @return Processed language concept.
+     */
+    private Concept processTypeElement(TypeElement typeElement, Concept superConcept) {
+        String name = typeElement.getQualifiedName().toString();
+        System.out.println("---->>> Name: " + name + " [kind:" + typeElement.getKind() + "]");
+        if (excludes.contains(name)) {
+            return null;
+        }
+
+        if (language.getName() != null && !language.getName().isEmpty() && name.startsWith(language.getName())) {
+            name = name.substring(language.getName().length() + 1); // +1 because of dot after package name '.'
+        }
+
+        Concept concept = language.getConcept(name);
+        if (concept != null) { // Already processed
+            if (superConcept != null) { // Set parent
+                concept.setParent(superConcept);
+            }
+            // TODO:toto som tu doplnil len docasne na vyskusanie pre podporu kompozicie jazykov, treba to cele prehodnotit, lebo sa to nachadza aj na konci metody
+            //processDirectSubclasses(typeElement, concept);
+            if (conceptsToProcess.contains(concept)) {
+                conceptsToProcess.remove(concept);
+            } else {
+                return concept;
+            }
+        } else {
+            // Create concept.
+            concept = new Concept(name, typeElement);
+            concept.setParent(superConcept); //Set parent
+            language.addConcept(concept);
+        }
+
+        processTypeElementAccordingToKind(typeElement, concept);
+
+        // Add concept pattern from annotations (ConceptPattern).
+        addPatternsFromAnnotations(typeElement, concept);
+        processDirectSubclasses(typeElement, concept);
+        return concept;
+    }
+
+    /**
+     * Processes language model element according to its kind.
+     *
+     * @param typeElement Language model element.
+     * @param concept Language concept for representing language model element.
+     */
+    private void processTypeElementAccordingToKind(TypeElement typeElement, Concept concept) {
+        if (typeElement.getKind() == ElementKind.ENUM) { // Enum type
+            processEnum(concept, typeElement);
+        } else if (typeElement.getKind() == ElementKind.CLASS) { // Class
+            System.out.println(" modifiers: " + typeElement.getModifiers());
+            if (typeElement.getModifiers().contains(Modifier.ABSTRACT)) { // Abstract class
+                processAbstractClass(concept, typeElement);
+            } else {  //Concrete class
+                processConcreteClass(concept, typeElement);
+            }
+        } else if (typeElement.getKind() == ElementKind.INTERFACE) { // Interface
+            processInterface(concept, typeElement);
+        } else {
+            throw new GeneratorException("Not supported type in model '" + typeElement + "'");
+        }
+    }
+
+    /**
+     * Processes Enum language model elements.
+     *
+     * @param concept Language concept representing language model element.
+     * @param typeElement Language model element.
+     */
+    private void processEnum(Concept concept, TypeElement typeElement) {
+        concept.addPattern(new yajco.model.pattern.impl.Enum());
+        for (Element element : typeElement.getEnclosedElements()) {
+            if (element.getKind() != ElementKind.ENUM_CONSTANT) {
+                continue; // Skip non enum constants.
+            }
+
+            Token tokenAnnotation = element.getAnnotation(Token.class);
+            Notation notation = new Notation(typeElement);
+            TokenPart tokenPart;
+            if (tokenAnnotation != null) {
+                tokenPart = new TokenPart(tokenAnnotation.value(), tokenAnnotation);
+            } else {
+                tokenPart = new TokenPart(element.getSimpleName().toString(), element);
+            }
+            notation.addPart(tokenPart);
+            concept.addNotation(notation);
+        }
+    }
+
+    /**
+     * Processes concrete classes of language model.
+     *
+     * @param concept Language concept representing language model element.
+     * @param classElement Language model element.
+     */
+    private void processConcreteClass(Concept concept, TypeElement classElement) {
+        defineAbstractSytax(concept, classElement);
+        defineConcreteSyntax(concept, classElement);
+    }
+
+    /**
+     * Parses concepts concrete syntax.
+     *
+     * @param concept Language concept representing language model element.
+     * @param classElement Language model element.
+     */
+    private void defineConcreteSyntax(Concept concept, TypeElement classElement) {
+        Set<ExecutableElement> constructors = getConstructorsAndFactoryMethods(classElement);
+
+        // Check for class-level @Before, @Keyword, and @After annotations
+        Before beforeClassAnnotation = classElement.getAnnotation(Before.class);
+        Keyword keywordClassAnnotation = classElement.getAnnotation(Keyword.class);
+        After afterClassAnnotation = classElement.getAnnotation(After.class);
+
+        // If there are no constructors but class has @Before, @Keyword, or @After annotations, create a default constructor notation
+        if (constructors.isEmpty() && (beforeClassAnnotation != null || keywordClassAnnotation != null || afterClassAnnotation != null)) {
+            Notation defaultNotation = new Notation(classElement);
+
+            // Apply class-level @Before annotation
+            if (beforeClassAnnotation != null) {
+                addTokenParts(defaultNotation, beforeClassAnnotation.value());
+            }
+
+            // Apply class-level @Keyword annotation
+            if (keywordClassAnnotation != null) {
+                addTokenParts(defaultNotation, keywordClassAnnotation.value());
+            }
+
+            // Apply class-level @After annotation
+            if (afterClassAnnotation != null) {
+                addTokenParts(defaultNotation, afterClassAnnotation.value());
+            }
+
+            concept.addNotation(defaultNotation);
+        }
+
+        for (ExecutableElement constructor : constructors) {
+            Notation notation = new Notation(constructor);
+
+            // Apply class-level @Before annotation first, if present
+            if (beforeClassAnnotation != null) {
+                addTokenParts(notation, beforeClassAnnotation.value());
+            }
+
+            // Apply class-level @Keyword annotation, if present
+            if (keywordClassAnnotation != null) {
+                addTokenParts(notation, keywordClassAnnotation.value());
+            }
+
+            // Then apply constructor-level @Before annotation
+            if (constructor.getAnnotation(Before.class) != null) {
+                addTokenParts(notation, constructor.getAnnotation(Before.class).value());
+            }
+
+            // Then apply constructor-level @Keyword annotation
+            if (constructor.getAnnotation(Keyword.class) != null) {
+                addTokenParts(notation, constructor.getAnnotation(Keyword.class).value());
+            }
+
+            // @UnorderedParameters annotation.
+            UnorderedParameters unorderedParametersAnnotation = constructor.getAnnotation(UnorderedParameters.class);
+            MixedRepetition mixedRepetitionAnnotation = constructor.getAnnotation(MixedRepetition.class);
+
+            if (unorderedParametersAnnotation != null) {
+                processUnorderedParamsConstructor(concept, constructor, notation, unorderedParametersAnnotation);
+            } else if (mixedRepetitionAnnotation != null) {
+                processMixedRepetitionConstructor(concept, constructor, notation, mixedRepetitionAnnotation);
+            } else {
+                for (VariableElement paramElement : constructor.getParameters()) {
+                    processParameter(concept, notation, paramElement);
+                }
+            }
+
+            // Apply constructor-level @After annotation
+            if (constructor.getAnnotation(After.class) != null) {
+                addTokenParts(notation, constructor.getAnnotation(After.class).value());
+            }
+
+            // Then apply class-level @After annotation, if present
+            if (afterClassAnnotation != null) {
+                addTokenParts(notation, afterClassAnnotation.value());
+            }
+
+            concept.addNotation(notation);
+            if (constructor.getKind() == ElementKind.METHOD) {
+                notation.addPattern(new Factory(constructor.getSimpleName().toString()));
+            }
+
+            //TODO: odstranit pri prenesesni @Operator na triedu
+            // Add concept pattern from annotations (Type).
+            addPatternsFromAnnotations(constructor, concept);
+        }
+    }
+
+    /**
+     * Processes constructor annotated with @UnorderedParameters annotation.
+     *
+     * @param concept Language concept.
+     * @param notation Language concept notation.
+     * @param unorderedParametersAnnotation UnorderedParameters annotation
+     */
+    private void processUnorderedParamsConstructor(Concept concept, ExecutableElement constructor, Notation notation, UnorderedParameters unorderedParametersAnnotation) {
+        int excludedCount = 0;
+        int unorderedCount = 0;
+        boolean cantBeExcluded = false;
+        boolean cantBeUnordered = false;
+
+        for (VariableElement paramElement : constructor.getParameters()) {
+            if (Arrays.asList(unorderedParametersAnnotation.exclude()).contains(paramElement.getSimpleName().toString())) {
+                processParameter(concept, notation, paramElement);
+                excludedCount++;
+                cantBeUnordered = unorderedCount > 0 && excludedCount > 0;
+            } else if (getType(paramElement.asType()) instanceof OptionalType)  {
+                UnorderedParamPart unorderedParamPart = new UnorderedParamPart(null);
+                OptionalPart optionalPart = (OptionalPart) processCompoundParameter(concept, paramElement, new OptionalPart(null));
+                unorderedParamPart.addPart(optionalPart);
+                notation.addPart(unorderedParamPart);
+                unorderedCount++;
+                cantBeExcluded = unorderedCount > 0 && excludedCount > 0;
+            } else {
+                UnorderedParamPart unorderedParamPart = new UnorderedParamPart(null);
+                processCompoundParameter(concept, paramElement, unorderedParamPart);
+                notation.addPart(unorderedParamPart);
+                unorderedCount++;
+                cantBeExcluded = unorderedCount > 0 && excludedCount > 0;
+            }
+
+            if (cantBeExcluded && cantBeUnordered) {
+                throw new GeneratorException("Excluded parameter can't be in the middle of unordered parameters.");
+            }
+        }
+    }
+
+    /**
+     * Processes constructor annotated with @MixedRepetition annotation.
+     *
+     * @param concept Language concept.
+     * @param constructor Constructor or factory method element.
+     * @param notation Language concept notation.
+     * @param mixedRepetitionAnnotation MixedRepetition annotation
+     */
+    private void processMixedRepetitionConstructor(Concept concept, ExecutableElement constructor, Notation notation, MixedRepetition mixedRepetitionAnnotation) {
+        MixedRepetitionPart mixedRepetitionPart = new MixedRepetitionPart(null);
+
+        for (VariableElement paramElement : constructor.getParameters()) {
+            String paramName = paramElement.getSimpleName().toString();
+
+            // Check if parameter is excluded
+            if (Arrays.asList(mixedRepetitionAnnotation.exclude()).contains(paramName)) {
+                processParameter(concept, notation, paramElement);
+            } else {
+                // Parameter should be a collection type (List or Array)
+                Type paramType = getType(paramElement.asType());
+
+                if (!(paramType instanceof ListType || paramType instanceof ArrayType)) {
+                    throw new GeneratorException(
+                        "Parameter '" + paramName + "' in @MixedRepetition must be a List or Array type. Found: " + paramType.getClass().getSimpleName()
+                    );
+                }
+
+                // Create property reference part for this collection parameter
+                Property property = concept.getProperty(paramName);
+                if (property == null) {
+                    property = new Property(paramName, paramType, null);
+                    concept.addProperty(property);
+                }
+
+                PropertyReferencePart propertyRefPart = new PropertyReferencePart(property, paramElement);
+
+                // Add patterns from annotations (e.g., @Before, @After on individual parameters)
+                addPatternsFromAnnotations(paramElement, propertyRefPart);
+
+                // Add this property reference to the mixed repetition part
+                mixedRepetitionPart.addPart(propertyRefPart);
+            }
+        }
+
+        // Add the mixed repetition part to the notation
+        if (mixedRepetitionPart.getParts().size() > 0) {
+            notation.addPart(mixedRepetitionPart);
+        }
+    }
+
+    /**
+     * Parses concepts abstract syntax.
+     *
+     * @param concept Language concept representing language model element.
+     * @param classElement Language model element.
+     */
+    private void defineAbstractSytax(Concept concept, TypeElement classElement) {
+        System.out.println("starting ProcessConcreteClass method");
+        for (Element element : classElement.getEnclosedElements()) {
+            System.out.println("- enclosedElement: " + element.getSimpleName().toString() + "[" + element.getKind() + "]");
+            if (element.getKind().isField()) {
+                System.out.println("+++ " + classElement.toString() + "> " + element.toString());
+                VariableElement fieldElement = (VariableElement) element;
+
+                // Add only fields with property patterns (PropertyPattern).
+                if (hasPatternAnnotations(fieldElement)) {
+                    Property property = new Property(fieldElement.getSimpleName().toString(), getType(fieldElement.asType()), fieldElement);
+                    addPatternsFromAnnotations(fieldElement, property);
+                    concept.addProperty(property);
+                }
+            }
+        }
+    }
+
+    /**
+     * Processes abstract classes of language model elements
+     *
+     * @param concept Language concept representing language model element.
+     * @param typeElement Language model element.
+     */
+    private void processAbstractClass(Concept concept, TypeElement typeElement) {
+        //TODO: toto je len docasne pre testovanie a pokial sa ujasni ako to chceme
+        //processConcreteClass(concept, typeElement);
+    }
+
+    /**
+     * Processes interfaces of language model elements
+     *
+     * @param concept Language concept representing language model element.
+     * @param typeElement Language model element.
+     */
+    private void processInterface(Concept concept, TypeElement typeElement) {
+    }
+
+    /**
+     * Processes parameters of constructor or factory method in language model.
+     *
+     * @param concept Language concept.
+     * @param notation Notation of language concept.
+     * @param paramElement Parameter of constructor or factory method.
+     */
+    private void processParameter(Concept concept, Notation notation, VariableElement paramElement) {
+        Type type = getType(paramElement.asType());
+        yajco.annotation.Flag flagAnnotation = paramElement.getAnnotation(yajco.annotation.Flag.class);
+
+        // Handle @Flag annotation on boolean parameters
+        if (flagAnnotation != null) {
+            if (!(type instanceof yajco.model.type.PrimitiveType
+                  && ((yajco.model.type.PrimitiveType) type).getPrimitiveTypeConst() == PrimitiveTypeConst.BOOLEAN)) {
+                throw new GeneratorException("@Flag annotation can only be used on boolean parameters");
+            }
+
+            String paramName = paramElement.getSimpleName().toString();
+            Property property = concept.getProperty(paramName);
+            if (property == null) {
+                property = new Property(paramName, type, null);
+                concept.addProperty(property);
+            }
+
+            // Create an optional part containing the flag token
+            OptionalPart optionalPart = new OptionalPart(null);
+            optionalPart.addPart(new TokenPart(flagAnnotation.value()));
+
+            // Add property reference with Flag pattern
+            PropertyReferencePart propertyRefPart = new PropertyReferencePart(property, paramElement);
+            propertyRefPart.addPattern(new yajco.model.pattern.impl.Flag(flagAnnotation.value(), flagAnnotation));
+            optionalPart.addPart(propertyRefPart);
+
+            notation.addPart(optionalPart);
+        } else if (type instanceof OptionalType) {
+            OptionalPart optionalPart = (OptionalPart) processCompoundParameter(concept, paramElement, new OptionalPart(null));
+            notation.addPart(optionalPart);
+        } else {
+            // @Keyword annotation.
+            if (paramElement.getAnnotation(Keyword.class) != null) {
+                addTokenParts(notation, paramElement.getAnnotation(Keyword.class).value());
+            }
+
+            // @Before annotation.
+            if (paramElement.getAnnotation(Before.class) != null) {
+                addTokenParts(notation, paramElement.getAnnotation(Before.class).value());
+            }
+
+            String paramName = paramElement.getSimpleName().toString();
+            TypeMirror typeMirror = paramElement.asType();
+            References references = paramElement.getAnnotation(References.class);
+            Token tokenAnnotation = paramElement.getAnnotation(Token.class);
+            StringToken stringTokenAnnotation = paramElement.getAnnotation(StringToken.class);
+            BindingNotationPart part = null;
+
+            if (references != null) { // @References annotation.
+                //TODO: zatial nie je podpora pre polia referencii, treba to vsak doriesit
+                type = getSimpleType(typeMirror);
+                LocalVariablePart localVariablePart = new LocalVariablePart(paramName, type, paramElement);
+                notation.addPart(localVariablePart);
+
+                part = processReferencedConcept(concept, paramElement, references, localVariablePart);
+            } else { // Property reference.
+                Property property = concept.getProperty(paramName);
+                if (property == null) {
+                    property = new Property(paramName, getType(typeMirror), null);
+                    concept.addProperty(property);
+                }
+
+                part = new PropertyReferencePart(property, paramElement);
+                notation.addPart(part);
+            }
+
+            if (tokenAnnotation != null) {
+                part.addPattern(new yajco.model.pattern.impl.Token(tokenAnnotation.value(), tokenAnnotation));
+            } else if (stringTokenAnnotation != null) {
+                TokenDef tokenDef = createStringTokenDef(stringTokenAnnotation);
+                part.addPattern(new yajco.model.pattern.impl.Token(tokenDef.getName(), tokenAnnotation));
+            } else if (references != null) {
+                // Automatically add IDENTIFIER token for @References parameters
+                ensureIdentifierTokenExists();
+                part.addPattern(new yajco.model.pattern.impl.Token(IDENTIFIER_TOKEN_NAME, references));
+            } else if (part instanceof PropertyReferencePart) {
+                // Check if the referenced property has @Identifier pattern
+                PropertyReferencePart propRefPart = (PropertyReferencePart) part;
+                if (propertyHasIdentifierPattern(propRefPart.getProperty())) {
+                    // Automatically add IDENTIFIER token for properties with @Identifier
+                    ensureIdentifierTokenExists();
+                    part.addPattern(new yajco.model.pattern.impl.Token(IDENTIFIER_TOKEN_NAME, paramElement));
+                }
+            }
+
+            // Add notation part pattern from annotations (NotationPartPattern).
+            addPatternsFromAnnotations(paramElement, part);
+
+            // @After annotation.
+            if (paramElement.getAnnotation(After.class) != null) {
+                addTokenParts(notation, paramElement.getAnnotation(After.class).value());
+            }
+        }
+    }
+
+    /**
+     * Processes compound parameters (Parameters which know their whole concrete syntax).
+     *
+     * @param concept Language concept.
+     * @param paramElement Parameter of constructor or factory method.
+     * @param notationPart Compound notation part.
+     *
+     * @return Compound notation part.
+     */
+    private CompoundNotationPart processCompoundParameter(Concept concept, VariableElement paramElement, CompoundNotationPart notationPart) {
+        // @Keyword annotation.
+        if (paramElement.getAnnotation(Keyword.class) != null) {
+            for (String value : paramElement.getAnnotation(Keyword.class).value()) {
+                notationPart.addPart(new TokenPart(value));
+            }
+        }
+
+        // @Before annotation.
+        if (paramElement.getAnnotation(Before.class) != null) {
+            for (String value : paramElement.getAnnotation(Before.class).value()) {
+                notationPart.addPart(new TokenPart(value));
+            }
+        }
+
+        String paramName = paramElement.getSimpleName().toString();
+        TypeMirror typeMirror = paramElement.asType();
+        References references = paramElement.getAnnotation(References.class);
+        Token tokenAnnotation = paramElement.getAnnotation(Token.class);
+        StringToken stringTokenAnnotation = paramElement.getAnnotation(StringToken.class);
+        BindingNotationPart part;
+
+        if (references != null) { // @References annotation.
+            Type type;
+            List<? extends TypeMirror> types = ((DeclaredType) typeMirror).getTypeArguments();
+            if (processingEnv.getTypeUtils().asElement(typeMirror).toString().equals(Optional.class.getName())) {
+                type = getSimpleType(types.get(types.size() - 1));
+            } else {
+                type = getSimpleType(typeMirror);
+            }
+            LocalVariablePart localVariablePart = new LocalVariablePart(paramName, type, paramElement);
+            notationPart.addPart(localVariablePart);
+            part = processReferencedConcept(concept, paramElement, references, localVariablePart);
+        } else { // Property reference.
+            Property property = concept.getProperty(paramName);
+            if (property == null) {
+                property = new Property(paramName, getType(typeMirror), null);
+                concept.addProperty(property);
+            }
+
+            part = new PropertyReferencePart(property, paramElement);
+            notationPart.addPart(part);
+        }
+
+        if (tokenAnnotation != null) {
+            part.addPattern(new yajco.model.pattern.impl.Token(tokenAnnotation.value(), tokenAnnotation));
+        } else if (stringTokenAnnotation != null) {
+            TokenDef tokenDef = createStringTokenDef(stringTokenAnnotation);
+            part.addPattern(new yajco.model.pattern.impl.Token(tokenDef.getName(), tokenAnnotation));
+        }
+
+        // Add notation part pattern from annotations (NotationPartPattern).
+        addPatternsFromAnnotations(paramElement, part);
+
+        // @After annotation.
+        if (paramElement.getAnnotation(After.class) != null) {
+            for (String value : paramElement.getAnnotation(After.class).value()) {
+                notationPart.addPart(new TokenPart(value));
+            }
+        }
+
+        return notationPart;
+    }
+
+    /**
+     * Creates token for string token and adds it to language.
+     *
+     * @param stringTokenAnnotation StringToken annotation.
+     * @return TokenDef
+     */
+    private TokenDef createStringTokenDef(StringToken stringTokenAnnotation) {
+        String regex = formatStringTokenRegex(stringTokenAnnotation);
+        TokenDef tokenDef = null;
+
+        for (TokenDef token: language.getTokens()) {
+            if (token.getName().contains(DEFAULT_STRING_TOKEN_NAME) && token.getRegexp().equals(regex)) {
+                // Use existing string token with the same regex.
+                tokenDef = token;
+            }
+        }
+
+        if (tokenDef == null) {
+            tokenDef = new TokenDef(DEFAULT_STRING_TOKEN_NAME + "_" + stringTokenId++, regex);
+        }
+
+        // Add string token to language.
+        addToListAsSet(language.getTokens(), Collections.singletonList(tokenDef),false);
+
+        return tokenDef;
+    }
+
+    /**
+     * Ensures IDENTIFIER token exists in the language definition.
+     * If the token doesn't exist, it creates and adds it automatically.
+     *
+     * @return TokenDef for IDENTIFIER token
+     */
+    private TokenDef ensureIdentifierTokenExists() {
+        // Check if IDENTIFIER token already exists
+        for (TokenDef token : language.getTokens()) {
+            if (token.getName().equals(IDENTIFIER_TOKEN_NAME)) {
+                return token;
+            }
+        }
+
+        // Create new IDENTIFIER token
+        TokenDef tokenDef = new TokenDef(IDENTIFIER_TOKEN_NAME, IDENTIFIER_TOKEN_REGEXP);
+
+        // Add IDENTIFIER token to language
+        addToListAsSet(language.getTokens(), Collections.singletonList(tokenDef), false);
+
+        return tokenDef;
+    }
+
+    /**
+     * Checks if a property has an @Identifier pattern.
+     *
+     * @param property Property to check
+     * @return true if property has @Identifier pattern, false otherwise
+     */
+    private boolean propertyHasIdentifierPattern(Property property) {
+        if (property == null) {
+            return false;
+        }
+        for (Pattern pattern : property.getPatterns()) {
+            if (pattern instanceof yajco.model.pattern.impl.Identifier) {
+                return true;
+            }
+        }
+        return false;
+    }
+
+    /**
+     * Formats regex from @StringToken annotation. Regex is used to match strings.
+     *
+     * @param stringTokenAnnotation StringToken annotation
+     * @return Regex for matching strings.
+     */
+    private String formatStringTokenRegex(StringToken stringTokenAnnotation) {
+        String delimiter = stringTokenAnnotation.delimiter();
+
+        if (delimiter.equals("\"") || delimiter.equals("'") || delimiter.equals("\\")) {
+            delimiter = "\\" + stringTokenAnnotation.delimiter();
+        }
+
+        return delimiter + "(?:\\\\" + delimiter + "|[^" + delimiter + "])*?" + delimiter;
+    }
+
+    /**
+     * Processes referenced concept.
+     *
+     * @param concept Language concept.
+     * @param paramElement Parameter of constructor or factory method.
+     * @param references References annotation.
+     * @param part  Local variable notation part.
+     * @return Binding notation part.
+     */
+    private BindingNotationPart processReferencedConcept(Concept concept, VariableElement paramElement, References references, LocalVariablePart part) {
+        String paramName = paramElement.getSimpleName().toString();
+        try {
+            references.value();
+        } catch (MirroredTypeException e) {
+            TypeElement referencedTypeElement = (TypeElement) processingEnv.getTypeUtils().asElement(e.getTypeMirror());
+            Concept referencedConcept = processTypeElement(referencedTypeElement);
+            Property property = null;
+            if (!references.field().isEmpty()) {
+                property = concept.getProperty(references.field());
+            }
+            if (property == null) {
+                property = findReferencedProperty(paramElement, referencedConcept, references.field());
+                if (property == null) {
+                    String propertyName;
+                    if (references.field().isEmpty()) {
+                        propertyName = paramName;
+                    } else {
+                        propertyName = references.field();
+                    }
+                    property = new Property(propertyName, new yajco.model.type.ReferenceType(referencedConcept, referencedTypeElement), e);
+                }
+                concept.addProperty(property);
+            }
+            // If names of notationPart and referenced property are identical, no need to fill property data to References pattern.
+            if (property.getName().equals(paramName)) {
+                property = null;
+            }
+            part.addPattern(new yajco.model.pattern.impl.References(referencedConcept, property, references));
+        }
+        return part;
+    }
+
+    /**
+     * Finds referenced property.
+     *
+     * @param paramElement Parameter of constructor or factory method in language model.
+     * @param referencedConcept Referenced concept.
+     * @param proposedName Referenced field name.
+     * @return Referenced property.
+     */
+    private Property findReferencedProperty(VariableElement paramElement, Concept referencedConcept, String proposedName) {
+        Element element = paramElement;
+
+        // Go up on tree until you find class element.
+        while (element != null && !element.getKind().isClass()) {
+            element = element.getEnclosingElement();
+        }
+
+        // Class element found.
+        if (element != null) {
+            for (Element elem : element.getEnclosedElements()) {
+                if (elem.getKind().isField()) {
+                    VariableElement fieldElement = (VariableElement) elem;
+                    Type fieldType = getType(fieldElement.asType());
+                    if (fieldType instanceof yajco.model.type.ReferenceType) {
+                        yajco.model.type.ReferenceType referenceType = (yajco.model.type.ReferenceType) fieldType;
+                        if (referenceType.getConcept().equals(referencedConcept)) {
+                            if (!proposedName.isEmpty() && !fieldElement.getSimpleName().toString().equals(proposedName)) {
+                                continue;
+                            }
+                            return new Property(fieldElement.getSimpleName().toString(), referenceType, fieldElement);
+                        }
+                    }
+                }
+            }
+        }
+        return null;
+    }
+
+    /**
+     * Finds YAJCo model type of parameter.
+     *
+     * @param type Element type.
+     * @return YAJCo model type of parameter.
+     */
+    private Type getType(TypeMirror type) {
+        if (type.getKind() == TypeKind.ARRAY) {
+            return new yajco.model.type.ArrayType(getSimpleType(((ArrayType) type).getComponentType()));
+        } else if (isSpecifiedClassType(type, List.class)) {
+            return getSpecifiedYajcoComponentType(type, ListType.class);
+        } else if (isSpecifiedClassType(type, Set.class)) {
+            return getSpecifiedYajcoComponentType(type, SetType.class);
+        } else if (isSpecifiedClassType(type, Optional.class)) {
+            return getSpecifiedYajcoComponentType(type, OptionalType.class);
+        } else {
+            return getSimpleType(type);
+        }
+    }
+
+    /**
+     * Finds YAJCo component type of element.
+     *
+     * @param type Type of language model element.
+     * @param yajcoType YAJCo model type.
+     * @param <T>
+     * @return YAJCo component type of element.
+     */
+    private <T extends ComponentType> T getSpecifiedYajcoComponentType(TypeMirror type, Class<T> yajcoType) {
+        if (type.getKind() != TypeKind.DECLARED) {
+            throw new GeneratorException("Type " + type.toString() + " is not class or interface");
+        }
+
+        System.out.println("************************ " + type.getKind());
+
+        List<? extends TypeMirror> types = ((DeclaredType) type).getTypeArguments();
+
+        if (types.isEmpty()) {
+            throw new GeneratorException("Not specified type for " + type.toString() + ", please use generics to specify inner type.");
+        } else {
+            try {
+                Constructor constructor = yajcoType.getConstructor(Type.class);
+                if (processingEnv.getTypeUtils().asElement(type).toString().equals(Optional.class.getName())) {
+                    // Component type as Optional. For example Optional<String[]>
+                    return (T) (constructor.newInstance(getType(types.get(types.size() - 1))));
+                }
+                return (T) constructor.newInstance(getSimpleType(types.get(types.size() - 1)));
+            } catch (NoSuchMethodException ex) {
+                throw new GeneratorException("Cannot find constructor for " + yajcoType.getName() + " with only " + Type.class.getName() + " paramater!", ex);
+            } catch (Exception ex) {
+                throw new GeneratorException("Cannot create new object (" + yajcoType.getName() + ") needed for type " + type.toString(), ex);
+            }
+        }
+    }
+
+    private boolean isSpecifiedClassType(TypeMirror type, Class clazz) {
+        TypeElement referencedTypeElement = (TypeElement) processingEnv.getTypeUtils().asElement(type);
+        return clazz != null && referencedTypeElement != null
+               && referencedTypeElement.getQualifiedName().toString().equals(clazz.getName());
+    }
+
+    /**
+     * Finds YAJCo model type of argument.
+     *
+     * @param type Type of language model element.
+     * @return YAJCo model type of argument.
+     */
+    private Type getSimpleType(TypeMirror type) {
+        if (type.getKind().isPrimitive()) {
+            PrimitiveTypeConst primTypeConst = PrimitiveTypeConst.INTEGER;
+            switch (type.getKind()) {
+                case BOOLEAN:
+                    primTypeConst = yajco.model.type.PrimitiveTypeConst.BOOLEAN;
+                    break;
+                case BYTE:
+                case SHORT:
+                case INT:
+                case LONG:
+                    primTypeConst = yajco.model.type.PrimitiveTypeConst.INTEGER;
+                    break;
+                case FLOAT:
+                case DOUBLE:
+                    primTypeConst = yajco.model.type.PrimitiveTypeConst.REAL;
+                    break;
+            }
+            return new yajco.model.type.PrimitiveType(primTypeConst, type);
+        } else if (type.toString().equals(String.class.getName())) {
+            return new yajco.model.type.PrimitiveType(PrimitiveTypeConst.STRING, type);
+        } else if (type.toString().equals(Boolean.class.getName())) {
+            return new yajco.model.type.PrimitiveType(PrimitiveTypeConst.BOOLEAN, type);
+        } else if (type.toString().equals(Byte.class.getName())
+                   || type.toString().equals(Short.class.getName())
+                   || type.toString().equals(Integer.class.getName())
+                   || type.toString().equals(Long.class.getName())) {
+            return new yajco.model.type.PrimitiveType(PrimitiveTypeConst.INTEGER, type);
+        } else if (type.toString().equals(Float.class.getName()) || type.toString().equals(Double.class.getName())) {
+            return new yajco.model.type.PrimitiveType(PrimitiveTypeConst.REAL, type);
+        } else if (type.getKind() == TypeKind.DECLARED) {
+            TypeElement referencedTypeElement = (TypeElement) processingEnv.getTypeUtils().asElement(type);
+            System.out.println("getSimpleType(): referencedTypeElement: " + referencedTypeElement);
+            if (referencedTypeElement != null && isKnownClass(referencedTypeElement)) {
+                return new yajco.model.type.ReferenceType(processTypeElement(referencedTypeElement), referencedTypeElement);
+            }
+        }
+        throw new GeneratorException("Unsupported simple type " + type + " [" + type.getKind() + "]");
+    }
+
+//    private yajco.model.pattern.impl.Range getRange(VariableElement paramElement, TypeMirror type) {
+//        yajco.annotation.Range range = paramElement.getAnnotation(yajco.annotation.Range.class);
+//        if (type.getKind() == TypeKind.ARRAY) {
+//            if (range != null) {
+//                return new yajco.model.pattern.impl.Range(range.minOccurs(), range.maxOccurs());
+//            }
+//        } else {
+//            if (range != null) {
+//                throw new GeneratorException("@Range should be applied only on array or list  type " + paramElement);
+//            }
+//        }
+//        return null;
+//    }
+
+    /**
+     * Finds all constructors nad factory methods in language model class.
+     *
+     * @param classElement Language model class.
+     * @return Set of executable elements (constructors and factory methods).
+     */
+    private Set<ExecutableElement> getConstructorsAndFactoryMethods(TypeElement classElement) {
+        Set<ExecutableElement> constructors = new HashSet<>();
+        for (Element element : processingEnv.getElementUtils().getAllMembers(classElement)) {
+            boolean isConstructor = isConstructor(element);
+            boolean isFactoryMethod = isFactoryMethod(element);
+
+            if (isConstructor || isFactoryMethod) {
+                constructors.add((ExecutableElement) element);
+            }
+        }
+
+        return constructors;
+    }
+
+    /**
+     * Checks if language model element is constructor.
+     *
+     * @param element Language model element.
+     * @return If element is constructor.
+     */
+    private boolean isConstructor(Element element) {
+        return element.getKind() == ElementKind.CONSTRUCTOR && element.getModifiers().contains(Modifier.PUBLIC)
+               && element.getAnnotation(Exclude.class) == null;
+    }
+
+    /**
+     * Checks if language model element is factory method.
+     *
+     * @param element Language model element.
+     * @return If element is factory method.
+     */
+    private boolean isFactoryMethod(Element element) {
+        return element.getKind() == ElementKind.METHOD && element.getModifiers().contains(Modifier.PUBLIC)
+               && element.getAnnotation(FactoryMethod.class) != null && element.getAnnotation(Exclude.class) == null;
+    }
+
+    /**
+     * Finds if element is already known class.
+     *
+     * @param element Language model element
+     * @return If element is already known class.
+     */
+    private boolean isKnownClass(Element element) {
+        if (element.getKind().isClass() || element.getKind().isInterface()) {
+            if (language.getConcept(((TypeElement) element).getQualifiedName().toString()) != null) {
+                return true;
+            }
+            for (Element elem : rootElements) {
+                if ((elem.getKind().isClass() || elem.getKind().isInterface()) && elem.equals(element)) {
+                    return true;
+                }
+            }
+        }
+        return false;
+    }
+
+    /**
+     * Returns the set of direct subtypes of the passes element.
+     *
+     * @param typeElement type element
+     * @return set of direct subtypes of the element.
+     */
+    private Set<TypeElement> getDirectSubtypes(TypeElement typeElement) {
+        Set<TypeElement> subclassElements = new HashSet<>();
+        for (Element element : rootElements) {
+            if (isDirectSubtype(typeElement, element)) {
+                subclassElements.add((TypeElement) element);
+            }
+        }
+
+        return subclassElements;
+    }
+
+    /**
+     * Returns true if superElement is the direct super class of the element.
+     * Otherwise returns false.
+     *
+     * @param superElement supertype
+     * @param element element
+     * @return true if superElement is the direct super class of the element.
+     */
+    private boolean isDirectSubtype(TypeElement superElement, Element element) {
+        Exclude excludeAnnotation = element.getAnnotation(Exclude.class);
+        int excludeAnnotationsLength = 0;
+        try {
+            if (excludeAnnotation != null) {
+                excludeAnnotation.value();
+            }
+        } catch (MirroredTypesException e) {
+            excludeAnnotationsLength = e.getTypeMirrors().size();
+        }
+        if (excludeAnnotation == null || excludeAnnotationsLength > 0) {
+            if (element.getKind().isClass() || element.getKind().isInterface()) {
+                TypeMirror superType = superElement.asType();
+                TypeElement typeElement = (TypeElement) element;
+                // Test superclass.
+                if (processingEnv.getTypeUtils().isSameType(typeElement.getSuperclass(), superType)) {
+                    return true;
+                }
+                // Test interfaces.
+                for (TypeMirror type : typeElement.getInterfaces()) {
+                    if (processingEnv.getTypeUtils().isSameType(type, superType)) {
+                        return true;
+                    }
+                }
+            }
+        }
+        return false;
+    }
+
+    private void addTokenParts(Notation notation, String[] values) {
+        for (String value : values) {
+            notation.addPart(new TokenPart(value));
+        }
+    }
+
+    //TOTO je klucove pre otvorenost procesora, kopiruje vzor uvedeny v anotacii do modelu
+    //TODO - navrhujem doplnit kontrolu podla typu vzoru
+    /**
+     * Finds if language model elements annotation is annotated with @MapsTo annotations.
+     *
+     * @param element Language model element.
+     * @param <T>
+     * @return If elements annotation contains annotated with @MapsTo annotations.
+     */
+    private <T extends Pattern> boolean hasPatternAnnotations(Element element) {
+        for (AnnotationMirror am : element.getAnnotationMirrors()) {
+            Element annotationElement = processingEnv.getTypeUtils().asElement(am.getAnnotationType());
+            MapsTo mapsTo = annotationElement.getAnnotation(MapsTo.class);
+            if (mapsTo != null) {
+                return true;
+            }
+        }
+        return false;
+    }
+
+    /**
+     * Adds patterns from annotations to language.
+     *
+     * @param element Language model element.
+     * @param patternSupport Language concept.
+     * @param <T>
+     */
+    private <T extends Pattern> void addPatternsFromAnnotations(Element element, PatternSupport<T> patternSupport) {
+        for (AnnotationMirror am : element.getAnnotationMirrors()) {
+            Element annotationElement = processingEnv.getTypeUtils().asElement(am.getAnnotationType());
+            MapsTo mapsTo = annotationElement.getAnnotation(MapsTo.class);
+            if (mapsTo != null) {
+                System.out.println("Processing annotation pattern: " + am);
+                String mapsToClass = mapsTo.value();
+                //String mapsToClass = null;
+//                try {
+//                    mapsTo.value();
+//                } catch (MirroredTypeException e) {
+//                    mapsToClass = e.getTypeMirror().toString();
+//                }
+
+                patternSupport.addPattern((T) createObjectFromAnnotation(mapsToClass, am));
+            }
+        }
+    }
+
+    /**
+     * Creates object from annotation.
+     *
+     * @param mapsToClass Class that reflects annotation function.
+     * @param am Annotation
+     * @return Pattern
+     */
+    private Pattern createObjectFromAnnotation(String mapsToClass, AnnotationMirror am) {
+        try {
+            Class<? extends Pattern> clazz = (Class<? extends Pattern>) Class.forName(mapsToClass);
+            Pattern pattern = clazz.newInstance();
+            // Copy from annotation into created object, according to the same names of annotation property and field.
+            Map<? extends ExecutableElement, ? extends AnnotationValue> values = processingEnv.getElementUtils().getElementValuesWithDefaults(am);
+            for (Map.Entry<? extends ExecutableElement, ? extends AnnotationValue> entry : values.entrySet()) {
+                String name = entry.getKey().getSimpleName().toString();
+                // For conversion see javax.​lang.​model.​element.​AnnotationValue
+                // TODO: Does not convert: arrays, annotation and classes
+                Object value = entry.getValue().getValue();
+                System.out.println("  " + name + " = " + value);
+                if (value instanceof VariableElement) {  // Enum value
+                    VariableElement enumField = (VariableElement) value;
+                    value = Enum.valueOf((Class<? extends Enum>) Class.forName(enumField.asType().toString()), enumField.getSimpleName().toString());
+                }
+                Field field = clazz.getDeclaredField(name);
+                field.setAccessible(true);
+                System.out.println(" >" + name + " = " + field.get(pattern));
+                field.set(pattern, value);
+                System.out.println(" >>" + name + " = " + field.get(pattern));
+            }
+            return pattern;
+        } catch (Exception e) {
+            // TODO: upravit vypis
+            throw new GeneratorException("Cannot instantiate class for @MapsTo, class " + mapsToClass, e);
+        }
+    }
+    /**
+     * Processes direct subclasses of language model element.
+     *
+     * @param typeElement Language model element.
+     * @param concept Language concept representing language model element.
+     */
+    private void processDirectSubclasses(TypeElement typeElement, Concept concept) {
+        System.out.print("DirectSubtypes of " + typeElement.getSimpleName() + " are: ");
+        for (TypeElement subtypeElement : getDirectSubtypes(typeElement)) {
+            System.out.print(subtypeElement.getSimpleName() + "  ");
+            processTypeElement(subtypeElement, concept);
+        }
+        System.out.println();
+    }
+
+    /**
+     * Adds new items to original list according to overwrite flag.
+     *
+     * @param originalList Original list.
+     * @param newItems List of new items.
+     * @param overwrite Overwrite flag.
+     * @param <T>
+     */
+    private <T> void addToListAsSet(List<T> originalList, List<T> newItems, boolean overwrite) {
+        for (T item : newItems) {
+            if (originalList.contains(item)) {
+                if (overwrite) {
+                    // dolezite je to, aby item.equals fungoval spravne
+                    originalList.remove(item); // odstrani povodny
+                    originalList.add(item); // vlozi novy
+                }
+            } else {
+                originalList.add(item);
+            }
+        }
+    }
+}

--- a/yajco-annotation-processor/src/main/java/yajco/annotation/processor/LanguageModelBuilder.java
+++ b/yajco-annotation-processor/src/main/java/yajco/annotation/processor/LanguageModelBuilder.java
@@ -19,7 +19,10 @@ import yajco.model.utilities.XMLLanguageFormatHelper;
 
 import javax.annotation.processing.ProcessingEnvironment;
 import javax.lang.model.element.*;
-import javax.lang.model.type.*;
+import javax.lang.model.type.ArrayType;
+import javax.lang.model.type.DeclaredType;
+import javax.lang.model.type.MirroredTypeException;
+import javax.lang.model.type.TypeMirror;
 import java.lang.reflect.Field;
 import java.util.*;
 import java.util.Optional;
@@ -28,17 +31,14 @@ public class LanguageModelBuilder {
     private Properties properties;
     private ProcessingEnvironment processingEnv;
     private final Set<? extends Element> rootElements;
-    private Set<String> excludes = new HashSet<>();
+    private final Set<String> excludes;
     private final TypeResolver typeResolver;
+    private ConceptRegistry conceptRegistry;
+
     /**
      * Builded language.
      */
     private Language language;
-
-    /**
-     * Set for concepts imported from previous JARs and needed for full analysis.
-     */
-    private Set<Concept> conceptsToProcess = new HashSet<>();
 
     /**
      * Used for creation of string tokens defined by @StringToken annotation.
@@ -65,6 +65,7 @@ public class LanguageModelBuilder {
 
         // Create language.
         language = new Language(mainElement);
+        conceptRegistry = new ConceptRegistry(language, rootElements, excludes, processingEnv.getTypeUtils());
         // Add main package name == language name.
         String mainElementName = mainElement.getQualifiedName().toString();
         String languageName = mainElementName.substring(0, mainElementName.lastIndexOf('.'));
@@ -90,7 +91,7 @@ public class LanguageModelBuilder {
     }
 
     public Concept resolveReferenceConcept(TypeElement typeElement) {
-        if (typeElement != null && isKnownClass(typeElement)) {
+        if (typeElement != null && conceptRegistry.isKnownClass(typeElement)) {
             return processTypeElement(typeElement);
         } else {
             return null;
@@ -260,8 +261,7 @@ public class LanguageModelBuilder {
 
             addToListAsSet(language.getSkips(), incLang.getSkips(), true);
             addToListAsSet(language.getTokens(), incLang.getTokens(), true);
-            conceptsToProcess.addAll(incLang.getConcepts());
-            language.getConcepts().addAll(incLang.getConcepts());
+            conceptRegistry.registerImportedConcepts(incLang.getConcepts());
         }
     }
 
@@ -360,38 +360,16 @@ public class LanguageModelBuilder {
      * @return Processed language concept.
      */
     private Concept processTypeElement(TypeElement typeElement, Concept superConcept) {
-        String name = typeElement.getQualifiedName().toString();
-        System.out.println("---->>> Name: " + name + " [kind:" + typeElement.getKind() + "]");
-        if (excludes.contains(name)) {
+        Concept existing = conceptRegistry.resolveKnown(typeElement);
+        Concept concept = conceptRegistry.getOrCreate(typeElement, superConcept);
+        if (concept == null) {
             return null;
         }
-
-        if (language.getName() != null && !language.getName().isEmpty() && name.startsWith(language.getName())) {
-            name = name.substring(language.getName().length() + 1); // +1 because of dot after package name '.'
-        }
-
-        Concept concept = language.getConcept(name);
-        if (concept != null) { // Already processed
-            if (superConcept != null) { // Set parent
-                concept.setParent(superConcept);
-            }
-            // TODO:toto som tu doplnil len docasne na vyskusanie pre podporu kompozicie jazykov, treba to cele prehodnotit, lebo sa to nachadza aj na konci metody
-            //processDirectSubclasses(typeElement, concept);
-            if (conceptsToProcess.contains(concept)) {
-                conceptsToProcess.remove(concept);
-            } else {
-                return concept;
-            }
-        } else {
-            // Create concept.
-            concept = new Concept(name, typeElement);
-            concept.setParent(superConcept); //Set parent
-            language.addConcept(concept);
+        if (existing != null && !conceptRegistry.consumeImportedConcept(concept)) {
+            return concept;
         }
 
         processTypeElementAccordingToKind(typeElement, concept);
-
-        // Add concept pattern from annotations (ConceptPattern).
         addPatternsFromAnnotations(typeElement, concept);
         processDirectSubclasses(typeElement, concept);
         return concept;
@@ -1082,80 +1060,6 @@ public class LanguageModelBuilder {
                && element.getAnnotation(FactoryMethod.class) != null && element.getAnnotation(Exclude.class) == null;
     }
 
-    /**
-     * Finds if element is already known class.
-     *
-     * @param element Language model element
-     * @return If element is already known class.
-     */
-    private boolean isKnownClass(Element element) {
-        if (element.getKind().isClass() || element.getKind().isInterface()) {
-            if (language.getConcept(((TypeElement) element).getQualifiedName().toString()) != null) {
-                return true;
-            }
-            for (Element elem : rootElements) {
-                if ((elem.getKind().isClass() || elem.getKind().isInterface()) && elem.equals(element)) {
-                    return true;
-                }
-            }
-        }
-        return false;
-    }
-
-    /**
-     * Returns the set of direct subtypes of the passes element.
-     *
-     * @param typeElement type element
-     * @return set of direct subtypes of the element.
-     */
-    private Set<TypeElement> getDirectSubtypes(TypeElement typeElement) {
-        Set<TypeElement> subclassElements = new HashSet<>();
-        for (Element element : rootElements) {
-            if (isDirectSubtype(typeElement, element)) {
-                subclassElements.add((TypeElement) element);
-            }
-        }
-
-        return subclassElements;
-    }
-
-    /**
-     * Returns true if superElement is the direct super class of the element.
-     * Otherwise returns false.
-     *
-     * @param superElement supertype
-     * @param element element
-     * @return true if superElement is the direct super class of the element.
-     */
-    private boolean isDirectSubtype(TypeElement superElement, Element element) {
-        Exclude excludeAnnotation = element.getAnnotation(Exclude.class);
-        int excludeAnnotationsLength = 0;
-        try {
-            if (excludeAnnotation != null) {
-                excludeAnnotation.value();
-            }
-        } catch (MirroredTypesException e) {
-            excludeAnnotationsLength = e.getTypeMirrors().size();
-        }
-        if (excludeAnnotation == null || excludeAnnotationsLength > 0) {
-            if (element.getKind().isClass() || element.getKind().isInterface()) {
-                TypeMirror superType = superElement.asType();
-                TypeElement typeElement = (TypeElement) element;
-                // Test superclass.
-                if (processingEnv.getTypeUtils().isSameType(typeElement.getSuperclass(), superType)) {
-                    return true;
-                }
-                // Test interfaces.
-                for (TypeMirror type : typeElement.getInterfaces()) {
-                    if (processingEnv.getTypeUtils().isSameType(type, superType)) {
-                        return true;
-                    }
-                }
-            }
-        }
-        return false;
-    }
-
     private void addTokenParts(Notation notation, String[] values) {
         for (String value : values) {
             notation.addPart(new TokenPart(value));
@@ -1247,15 +1151,12 @@ public class LanguageModelBuilder {
      * Processes direct subclasses of language model element.
      *
      * @param typeElement Language model element.
-     * @param concept Language concept representing language model element.
+     * @param concept Language concept representing a language model element.
      */
     private void processDirectSubclasses(TypeElement typeElement, Concept concept) {
-        System.out.print("DirectSubtypes of " + typeElement.getSimpleName() + " are: ");
-        for (TypeElement subtypeElement : getDirectSubtypes(typeElement)) {
-            System.out.print(subtypeElement.getSimpleName() + "  ");
+        for (TypeElement subtypeElement : conceptRegistry.directSubtypesOf(typeElement)) {
             processTypeElement(subtypeElement, concept);
         }
-        System.out.println();
     }
 
     /**

--- a/yajco-annotation-processor/src/main/java/yajco/annotation/processor/LanguageModelBuilder.java
+++ b/yajco-annotation-processor/src/main/java/yajco/annotation/processor/LanguageModelBuilder.java
@@ -68,7 +68,8 @@ public class LanguageModelBuilder {
         conceptRegistry = new ConceptRegistry(language, rootElements, excludes, processingEnv.getTypeUtils());
         // Add main package name == language name.
         String mainElementName = mainElement.getQualifiedName().toString();
-        String languageName = mainElementName.substring(0, mainElementName.lastIndexOf('.'));
+        int lastDotIndex = mainElementName.lastIndexOf('.');
+        String languageName = lastDotIndex >= 0 ? mainElementName.substring(0, lastDotIndex) : "";
         System.out.println("---- mainElementName: " + mainElementName + " == languageName: " + languageName);
         if (!languageName.isEmpty()) {
             language.setName(languageName);

--- a/yajco-annotation-processor/src/main/java/yajco/annotation/processor/LanguageModelBuilder.java
+++ b/yajco-annotation-processor/src/main/java/yajco/annotation/processor/LanguageModelBuilder.java
@@ -9,7 +9,6 @@ import yajco.annotation.reference.References;
 import yajco.generator.GeneratorException;
 import yajco.model.*;
 import yajco.model.pattern.Pattern;
-import yajco.model.pattern.PatternSupport;
 import yajco.model.pattern.impl.Factory;
 import yajco.model.type.ListType;
 import yajco.model.type.OptionalType;
@@ -23,7 +22,6 @@ import javax.lang.model.type.ArrayType;
 import javax.lang.model.type.DeclaredType;
 import javax.lang.model.type.MirroredTypeException;
 import javax.lang.model.type.TypeMirror;
-import java.lang.reflect.Field;
 import java.util.*;
 import java.util.Optional;
 
@@ -34,6 +32,7 @@ public class LanguageModelBuilder {
     private final Set<String> excludes;
     private final TypeResolver typeResolver;
     private ConceptRegistry conceptRegistry;
+    private PatternMapper patternMapper;
 
     /**
      * Builded language.
@@ -54,6 +53,7 @@ public class LanguageModelBuilder {
         this.rootElements = rootElements;
         this.excludes = excludes;
         this.typeResolver = new TypeResolver(processingEnv.getTypeUtils(), this::resolveReferenceConcept);
+        this.patternMapper = new PatternMapper(processingEnv);
     }
 
     public Language createLanguageModel(Element parserAnnotationElement, Parser parserAnnotation) {
@@ -370,7 +370,7 @@ public class LanguageModelBuilder {
         }
 
         processTypeElementAccordingToKind(typeElement, concept);
-        addPatternsFromAnnotations(typeElement, concept);
+        patternMapper.addPatternsFromAnnotations(typeElement, concept);
         processDirectSubclasses(typeElement, concept);
         return concept;
     }
@@ -525,7 +525,7 @@ public class LanguageModelBuilder {
 
             //TODO: odstranit pri prenesesni @Operator na triedu
             // Add concept pattern from annotations (Type).
-            addPatternsFromAnnotations(constructor, concept);
+            patternMapper.addPatternsFromAnnotations(constructor, concept);
         }
     }
 
@@ -605,7 +605,7 @@ public class LanguageModelBuilder {
                 PropertyReferencePart propertyRefPart = new PropertyReferencePart(property, paramElement);
 
                 // Add patterns from annotations (e.g., @Before, @After on individual parameters)
-                addPatternsFromAnnotations(paramElement, propertyRefPart);
+                patternMapper.addPatternsFromAnnotations(paramElement, propertyRefPart);
 
                 // Add this property reference to the mixed repetition part
                 mixedRepetitionPart.addPart(propertyRefPart);
@@ -633,12 +633,12 @@ public class LanguageModelBuilder {
                 VariableElement fieldElement = (VariableElement) element;
 
                 // Add only fields with property patterns (PropertyPattern).
-                if (hasPatternAnnotations(fieldElement)) {
+                if (patternMapper.hasPatternAnnotations(fieldElement)) {
                     Property property = new Property(
                         fieldElement.getSimpleName().toString(),
                         typeResolver.getType(fieldElement.asType()),
                         fieldElement);
-                    addPatternsFromAnnotations(fieldElement, property);
+                    patternMapper.addPatternsFromAnnotations(fieldElement, property);
                     concept.addProperty(property);
                 }
             }
@@ -759,7 +759,7 @@ public class LanguageModelBuilder {
             }
 
             // Add notation part pattern from annotations (NotationPartPattern).
-            addPatternsFromAnnotations(paramElement, part);
+            patternMapper.addPatternsFromAnnotations(paramElement, part);
 
             // @After annotation.
             if (paramElement.getAnnotation(After.class) != null) {
@@ -829,7 +829,7 @@ public class LanguageModelBuilder {
         }
 
         // Add notation part pattern from annotations (NotationPartPattern).
-        addPatternsFromAnnotations(paramElement, part);
+        patternMapper.addPatternsFromAnnotations(paramElement, part);
 
         // @After annotation.
         if (paramElement.getAnnotation(After.class) != null) {
@@ -1066,87 +1066,6 @@ public class LanguageModelBuilder {
         }
     }
 
-    //TOTO je klucove pre otvorenost procesora, kopiruje vzor uvedeny v anotacii do modelu
-    //TODO - navrhujem doplnit kontrolu podla typu vzoru
-    /**
-     * Finds if language model elements annotation is annotated with @MapsTo annotations.
-     *
-     * @param element Language model element.
-     * @param <T>
-     * @return If elements annotation contains annotated with @MapsTo annotations.
-     */
-    private <T extends Pattern> boolean hasPatternAnnotations(Element element) {
-        for (AnnotationMirror am : element.getAnnotationMirrors()) {
-            Element annotationElement = processingEnv.getTypeUtils().asElement(am.getAnnotationType());
-            MapsTo mapsTo = annotationElement.getAnnotation(MapsTo.class);
-            if (mapsTo != null) {
-                return true;
-            }
-        }
-        return false;
-    }
-
-    /**
-     * Adds patterns from annotations to language.
-     *
-     * @param element Language model element.
-     * @param patternSupport Language concept.
-     * @param <T>
-     */
-    private <T extends Pattern> void addPatternsFromAnnotations(Element element, PatternSupport<T> patternSupport) {
-        for (AnnotationMirror am : element.getAnnotationMirrors()) {
-            Element annotationElement = processingEnv.getTypeUtils().asElement(am.getAnnotationType());
-            MapsTo mapsTo = annotationElement.getAnnotation(MapsTo.class);
-            if (mapsTo != null) {
-                System.out.println("Processing annotation pattern: " + am);
-                String mapsToClass = mapsTo.value();
-                //String mapsToClass = null;
-//                try {
-//                    mapsTo.value();
-//                } catch (MirroredTypeException e) {
-//                    mapsToClass = e.getTypeMirror().toString();
-//                }
-
-                patternSupport.addPattern((T) createObjectFromAnnotation(mapsToClass, am));
-            }
-        }
-    }
-
-    /**
-     * Creates object from annotation.
-     *
-     * @param mapsToClass Class that reflects annotation function.
-     * @param am Annotation
-     * @return Pattern
-     */
-    private Pattern createObjectFromAnnotation(String mapsToClass, AnnotationMirror am) {
-        try {
-            Class<? extends Pattern> clazz = (Class<? extends Pattern>) Class.forName(mapsToClass);
-            Pattern pattern = clazz.newInstance();
-            // Copy from annotation into created object, according to the same names of annotation property and field.
-            Map<? extends ExecutableElement, ? extends AnnotationValue> values = processingEnv.getElementUtils().getElementValuesWithDefaults(am);
-            for (Map.Entry<? extends ExecutableElement, ? extends AnnotationValue> entry : values.entrySet()) {
-                String name = entry.getKey().getSimpleName().toString();
-                // For conversion see javax.​lang.​model.​element.​AnnotationValue
-                // TODO: Does not convert: arrays, annotation and classes
-                Object value = entry.getValue().getValue();
-                System.out.println("  " + name + " = " + value);
-                if (value instanceof VariableElement) {  // Enum value
-                    VariableElement enumField = (VariableElement) value;
-                    value = Enum.valueOf((Class<? extends Enum>) Class.forName(enumField.asType().toString()), enumField.getSimpleName().toString());
-                }
-                Field field = clazz.getDeclaredField(name);
-                field.setAccessible(true);
-                System.out.println(" >" + name + " = " + field.get(pattern));
-                field.set(pattern, value);
-                System.out.println(" >>" + name + " = " + field.get(pattern));
-            }
-            return pattern;
-        } catch (Exception e) {
-            // TODO: upravit vypis
-            throw new GeneratorException("Cannot instantiate class for @MapsTo, class " + mapsToClass, e);
-        }
-    }
     /**
      * Processes direct subclasses of language model element.
      *

--- a/yajco-annotation-processor/src/main/java/yajco/annotation/processor/PatternMapper.java
+++ b/yajco-annotation-processor/src/main/java/yajco/annotation/processor/PatternMapper.java
@@ -1,0 +1,93 @@
+package yajco.annotation.processor;
+
+import yajco.generator.GeneratorException;
+import yajco.model.pattern.Pattern;
+import yajco.model.pattern.PatternSupport;
+
+import javax.annotation.processing.ProcessingEnvironment;
+import javax.lang.model.element.*;
+import java.lang.reflect.Field;
+import java.util.Map;
+
+public class PatternMapper {
+    private final ProcessingEnvironment processingEnv;
+
+    public PatternMapper(ProcessingEnvironment processingEnv) {
+        this.processingEnv = processingEnv;
+    }
+
+    //TOTO je klucove pre otvorenost procesora, kopiruje vzor uvedeny v anotacii do modelu
+    //TODO - navrhujem doplnit kontrolu podla typu vzoru
+    /**
+     * Finds if language model elements annotation is annotated with @MapsTo annotations.
+     *
+     * @param element Language model element.
+     * @param <T>
+     * @return If elements annotation contains annotated with @MapsTo annotations.
+     */
+    public <T extends Pattern> boolean hasPatternAnnotations(Element element) {
+        for (AnnotationMirror am : element.getAnnotationMirrors()) {
+            Element annotationElement = processingEnv.getTypeUtils().asElement(am.getAnnotationType());
+            MapsTo mapsTo = annotationElement.getAnnotation(MapsTo.class);
+            if (mapsTo != null) {
+                return true;
+            }
+        }
+        return false;
+    }
+
+    /**
+     * Adds patterns from annotations to language.
+     *
+     * @param element Language model element.
+     * @param patternSupport Language concept.
+     * @param <T>
+     */
+    public <T extends Pattern> void addPatternsFromAnnotations(Element element, PatternSupport<T> patternSupport) {
+        for (AnnotationMirror am : element.getAnnotationMirrors()) {
+            Element annotationElement = processingEnv.getTypeUtils().asElement(am.getAnnotationType());
+            MapsTo mapsTo = annotationElement.getAnnotation(MapsTo.class);
+            if (mapsTo != null) {
+                System.out.println("Processing annotation pattern: " + am);
+                String mapsToClass = mapsTo.value();
+                patternSupport.addPattern((T) createObjectFromAnnotation(mapsToClass, am));
+            }
+        }
+    }
+
+    /**
+     * Creates object from annotation.
+     *
+     * @param mapsToClass Class that reflects annotation function.
+     * @param am Annotation
+     * @return Pattern
+     */
+    private Pattern createObjectFromAnnotation(String mapsToClass, AnnotationMirror am) {
+        try {
+            Class<? extends Pattern> clazz = (Class<? extends Pattern>) Class.forName(mapsToClass);
+            Pattern pattern = clazz.getConstructor().newInstance();
+            // Copy from annotation into created object, according to the same names of annotation property and field.
+            Map<? extends ExecutableElement, ? extends AnnotationValue> values = processingEnv.getElementUtils().getElementValuesWithDefaults(am);
+            for (Map.Entry<? extends ExecutableElement, ? extends AnnotationValue> entry : values.entrySet()) {
+                String name = entry.getKey().getSimpleName().toString();
+                // For conversion see javax.​lang.​model.​element.​AnnotationValue
+                // TODO: Does not convert: arrays, annotation and classes
+                Object value = entry.getValue().getValue();
+                System.out.println("  " + name + " = " + value);
+                if (value instanceof VariableElement) {  // Enum value
+                    VariableElement enumField = (VariableElement) value;
+                    value = Enum.valueOf((Class<? extends Enum>) Class.forName(enumField.asType().toString()), enumField.getSimpleName().toString());
+                }
+                Field field = clazz.getDeclaredField(name);
+                field.setAccessible(true);
+                System.out.println(" >" + name + " = " + field.get(pattern));
+                field.set(pattern, value);
+                System.out.println(" >>" + name + " = " + field.get(pattern));
+            }
+            return pattern;
+        } catch (Exception e) {
+            // TODO: upravit vypis
+            throw new GeneratorException("Cannot instantiate class for @MapsTo, class " + mapsToClass, e);
+        }
+    }
+}

--- a/yajco-annotation-processor/src/main/java/yajco/annotation/processor/PatternMapper.java
+++ b/yajco-annotation-processor/src/main/java/yajco/annotation/processor/PatternMapper.java
@@ -73,16 +73,13 @@ public class PatternMapper {
                 // For conversion see javax.​lang.​model.​element.​AnnotationValue
                 // TODO: Does not convert: arrays, annotation and classes
                 Object value = entry.getValue().getValue();
-                System.out.println("  " + name + " = " + value);
                 if (value instanceof VariableElement) {  // Enum value
                     VariableElement enumField = (VariableElement) value;
                     value = Enum.valueOf((Class<? extends Enum>) Class.forName(enumField.asType().toString()), enumField.getSimpleName().toString());
                 }
                 Field field = clazz.getDeclaredField(name);
                 field.setAccessible(true);
-                System.out.println(" >" + name + " = " + field.get(pattern));
                 field.set(pattern, value);
-                System.out.println(" >>" + name + " = " + field.get(pattern));
             }
             return pattern;
         } catch (Exception e) {

--- a/yajco-annotation-processor/src/main/java/yajco/annotation/processor/TypeResolver.java
+++ b/yajco-annotation-processor/src/main/java/yajco/annotation/processor/TypeResolver.java
@@ -1,0 +1,138 @@
+package yajco.annotation.processor;
+
+import yajco.generator.GeneratorException;
+import yajco.model.Concept;
+import yajco.model.type.*;
+
+import javax.lang.model.element.TypeElement;
+import javax.lang.model.type.DeclaredType;
+import javax.lang.model.type.TypeKind;
+import javax.lang.model.type.TypeMirror;
+import javax.lang.model.util.Types;
+import java.lang.reflect.Constructor;
+import java.util.List;
+import java.util.Optional;
+import java.util.Set;
+
+/**
+ * Maps Java types to YAJCo model types.
+ */
+public class TypeResolver {
+    public interface ConceptTypeGateway {
+        Concept resolveIfKnown(TypeElement typeElement); // returns null if not model concept
+    }
+
+    private final Types typeUtils;
+    private final ConceptTypeGateway conceptGateway;
+
+    public TypeResolver(Types typeUtils, ConceptTypeGateway conceptGateway) {
+        this.typeUtils = typeUtils;
+        this.conceptGateway = conceptGateway;
+    }
+
+    /**
+     * Finds YAJCo model type of parameter.
+     *
+     * @param type Element type.
+     * @return YAJCo model type of parameter.
+     */
+    public Type getType(TypeMirror type) {
+        if (type.getKind() == TypeKind.ARRAY) {
+            return new ArrayType(
+                getSimpleType(((javax.lang.model.type.ArrayType) type).getComponentType()));
+        } else if (isSpecifiedClassType(type, List.class)) {
+            return getSpecifiedYajcoComponentType(type, ListType.class);
+        } else if (isSpecifiedClassType(type, Set.class)) {
+            return getSpecifiedYajcoComponentType(type, SetType.class);
+        } else if (isSpecifiedClassType(type, Optional.class)) {
+            return getSpecifiedYajcoComponentType(type, OptionalType.class);
+        } else {
+            return getSimpleType(type);
+        }
+    }
+
+    /**
+     * Finds YAJCo component type of element.
+     *
+     * @param type Type of language model element.
+     * @param yajcoType YAJCo model type.
+     * @return YAJCo component type of element.
+     */
+    private <T extends ComponentType> T getSpecifiedYajcoComponentType(TypeMirror type, Class<T> yajcoType) {
+        if (type.getKind() != TypeKind.DECLARED) {
+            throw new GeneratorException("Type " + type + " is not class or interface");
+        }
+
+        System.out.println("************************ " + type.getKind());
+
+        List<? extends TypeMirror> types = ((DeclaredType) type).getTypeArguments();
+
+        if (types.isEmpty()) {
+            throw new GeneratorException("Not specified type for " + type + ", please use generics to specify inner type.");
+        } else {
+            try {
+                Constructor<T> constructor = yajcoType.getConstructor(Type.class);
+                if (typeUtils.asElement(type).toString().equals(Optional.class.getName())) {
+                    // Component type as Optional. For example Optional<String[]>
+                    return constructor.newInstance(getType(types.get(types.size() - 1)));
+                }
+                return constructor.newInstance(getSimpleType(types.get(types.size() - 1)));
+            } catch (NoSuchMethodException ex) {
+                throw new GeneratorException("Cannot find constructor for " + yajcoType.getName() + " with only " + Type.class.getName() + " paramater!", ex);
+            } catch (Exception ex) {
+                throw new GeneratorException("Cannot create new object (" + yajcoType.getName() + ") needed for type " + type, ex);
+            }
+        }
+    }
+
+    private boolean isSpecifiedClassType(TypeMirror type, Class<?> clazz) {
+        TypeElement referencedTypeElement = (TypeElement) typeUtils.asElement(type);
+        return clazz != null && referencedTypeElement != null
+               && referencedTypeElement.getQualifiedName().toString().equals(clazz.getName());
+    }
+
+    /**
+     * Finds YAJCo model type of argument.
+     *
+     * @param type Type of language model element.
+     * @return YAJCo model type of argument.
+     */
+    public Type getSimpleType(TypeMirror type) {
+        if (type.getKind().isPrimitive()) {
+            PrimitiveTypeConst primTypeConst = PrimitiveTypeConst.INTEGER;
+            switch (type.getKind()) {
+                case BOOLEAN:
+                    primTypeConst = PrimitiveTypeConst.BOOLEAN;
+                    break;
+                case BYTE:
+                case SHORT:
+                case INT:
+                case LONG:
+                    primTypeConst = PrimitiveTypeConst.INTEGER;
+                    break;
+                case FLOAT:
+                case DOUBLE:
+                    primTypeConst = PrimitiveTypeConst.REAL;
+                    break;
+            }
+            return new PrimitiveType(primTypeConst, type);
+        } else if (type.toString().equals(String.class.getName())) {
+            return new PrimitiveType(PrimitiveTypeConst.STRING, type);
+        } else if (type.toString().equals(Boolean.class.getName())) {
+            return new PrimitiveType(PrimitiveTypeConst.BOOLEAN, type);
+        } else if (type.toString().equals(Byte.class.getName())
+                   || type.toString().equals(Short.class.getName())
+                   || type.toString().equals(Integer.class.getName())
+                   || type.toString().equals(Long.class.getName())) {
+            return new PrimitiveType(PrimitiveTypeConst.INTEGER, type);
+        } else if (type.toString().equals(Float.class.getName()) || type.toString().equals(Double.class.getName())) {
+            return new PrimitiveType(PrimitiveTypeConst.REAL, type);
+        } else if (type.getKind() == TypeKind.DECLARED) {
+            TypeElement referencedTypeElement = (TypeElement) typeUtils.asElement(type);
+            System.out.println("getSimpleType(): referencedTypeElement: " + referencedTypeElement);
+            Concept c = conceptGateway.resolveIfKnown(referencedTypeElement);
+            if (c != null) return new ReferenceType(c, referencedTypeElement);
+        }
+        throw new GeneratorException("Unsupported simple type " + type + " [" + type.getKind() + "]");
+    }
+}

--- a/yajco-annotation-processor/src/main/java/yajco/annotation/processor/TypeResolver.java
+++ b/yajco-annotation-processor/src/main/java/yajco/annotation/processor/TypeResolver.java
@@ -63,10 +63,7 @@ public class TypeResolver {
             throw new GeneratorException("Type " + type + " is not class or interface");
         }
 
-        System.out.println("************************ " + type.getKind());
-
         List<? extends TypeMirror> types = ((DeclaredType) type).getTypeArguments();
-
         if (types.isEmpty()) {
             throw new GeneratorException("Not specified type for " + type + ", please use generics to specify inner type.");
         } else {
@@ -129,7 +126,6 @@ public class TypeResolver {
             return new PrimitiveType(PrimitiveTypeConst.REAL, type);
         } else if (type.getKind() == TypeKind.DECLARED) {
             TypeElement referencedTypeElement = (TypeElement) typeUtils.asElement(type);
-            System.out.println("getSimpleType(): referencedTypeElement: " + referencedTypeElement);
             Concept c = conceptGateway.resolveIfKnown(referencedTypeElement);
             if (c != null) return new ReferenceType(c, referencedTypeElement);
         }


### PR DESCRIPTION
Splitting the annotation processor into multiple classes:

- `AnnotationProcessor` – main orchestration of model building and generation
- `LanguageModelBuilder` – building language model
- `ConceptRegistry` – registry of language concepts used during model building
- `TypeResolver` – mapping of Java types to YAJCo model types
- `PatternMapper` – mapping of pattern annotations with `@MapsTo` metaannotation 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Expanded annotation processing to generate richer language models, including improved handling of parsers and languages, concepts, `@MapsTo`-driven patterns, references, tokens, skips, and optional parameters.
  * Added support for importing and reusing external language definitions.
* **Refactor**
  * Reworked the generation pipeline to delegate model-building, concept management, pattern extraction, and type-to-model mapping to dedicated helpers for more consistent compilation-time output.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->