### PR TITLE
Unify comments configuration between `@Language` and `@Parser` annotations

### DIFF
--- a/docs/user-guide.md
+++ b/docs/user-guide.md
@@ -449,7 +449,7 @@ Parameters:
   * `TokenDef[] tokens() default {}`
     * contains a list of named lexical symbols (tokens)
   * `Skip[] skips() default {}`
-    * contains a list of ignored (whitespace) characters as regular expressions; if left empty, YAJCo automatically includes `\s` regular expression for whitespaces
+    * contains a list of parser skip rules (whitespace/comments/custom regex); if left empty, YAJCo automatically includes `\s`
   * `Option[] options() default {}`
     * provides a way for configuration of YAJCo and modules
 
@@ -464,11 +464,9 @@ Its parameters allow specifying the root concept of the language, the name of th
                 @TokenDef(name = "ID", regexp = "[a-zA-Z][a-zA-Z0-9]*")
         },
         skips = {
-                @Skip("#.*\\n"), //comment
-                @Skip(" "),
-                @Skip("\\t"),
-                @Skip("\\n"),
-                @Skip("\\r")
+                @Skip(whitespace = true),
+                @Skip(lineComment = "#"),
+                @Skip(blockComment = {"/*", "*/"})
         }) package yajco.example.sml.model;
 
 import yajco.annotation.config.Parser;
@@ -491,8 +489,25 @@ Used as part of configuration in `@Parser` annotation parameter `tokens`.
 
 Parameters:
 
-  * `String value()`
-    * a set of characters or regular expression to be skipped during parsing
+  * `String value() default ""`
+    * raw regexp to skip
+  * `boolean whitespace() default false`
+    * shorthand for `\s`
+  * `String lineComment() default ""`
+    * line-comment prefix (for example `//`, `#`, `--`)
+    * generates skip regexp `escape(prefix) + ".*"`
+    * also populates IR comment metadata
+  * `String[] blockComment() default {}`
+    * block-comment delimiters `{start, end}`
+    * must have exactly two elements
+    * generates skip regexp `escape(start) + "(?:(?!" + escape(end) + ")[\\s\\S])*" + escape(end)`
+    * also populates IR comment metadata
+  * `@Deprecated String start() default ""`, `@Deprecated String end() default ""`
+    * legacy comment syntax, kept for backward compatibility
+    * prefer `blockComment = {start, end}`
+
+Priority inside one `@Skip` entry:
+`value` > `whitespace` > `lineComment` > `blockComment` > deprecated `start/end`.
 
 Used as part of configuration in `@Parser` annotation parameter `skips`.
 

--- a/docs/user-guide.md
+++ b/docs/user-guide.md
@@ -494,15 +494,18 @@ Parameters:
   * `boolean whitespace() default false`
     * shorthand for `\s`
   * `String lineComment() default ""`
+    * :sparkles: new in YAJCo 0.7
     * line-comment prefix (for example `//`, `#`, `--`)
     * generates skip regexp `escape(prefix) + ".*"`
     * also populates IR comment metadata
   * `String[] blockComment() default {}`
+    * :sparkles: new in YAJCo 0.7
     * block-comment delimiters `{start, end}`
     * must have exactly two elements
     * generates skip regexp `escape(start) + "(?:(?!" + escape(end) + ")[\\s\\S])*" + escape(end)`
     * also populates IR comment metadata
-  * `@Deprecated String start() default ""`, `@Deprecated String end() default ""`
+  * `String start() default ""`, `String end() default ""`
+    * :warning: deprecated in YAJCo 0.7
     * legacy comment syntax, kept for backward compatibility
     * prefer `blockComment = {start, end}`
 

--- a/yajco-annotation-processor/src/main/java/yajco/annotation/processor/LanguageModelBuilder.java
+++ b/yajco-annotation-processor/src/main/java/yajco/annotation/processor/LanguageModelBuilder.java
@@ -231,6 +231,9 @@ public class LanguageModelBuilder {
         }
         for (Skip skip : parserAnnotation.skips()) {
             SkipConversionResult conversion = convertSkip(skip, parserAnnotationElement);
+            if (conversion.regexp.isEmpty()) {
+                continue;
+            }
             skips.add(new SkipDef(conversion.regexp, skip));
             if (conversion.lineComment != null) {
                 properties.setProperty("yajco.ir.lineComment", conversion.lineComment);

--- a/yajco-annotation-processor/src/main/java/yajco/annotation/processor/LanguageModelBuilder.java
+++ b/yajco-annotation-processor/src/main/java/yajco/annotation/processor/LanguageModelBuilder.java
@@ -188,63 +188,10 @@ public class LanguageModelBuilder {
                 String.join(",", lang.fileExtensions()));
         }
 
-        // Comment syntax — stored as explicit properties for the IR generator
-        if (!lang.lineComment().isEmpty()) {
-            properties.setProperty("yajco.ir.lineComment", lang.lineComment());
-        }
-        if (lang.blockComment().length == 2) {
-            properties.setProperty("yajco.ir.blockComment.start", lang.blockComment()[0]);
-            properties.setProperty("yajco.ir.blockComment.end", lang.blockComment()[1]);
-        }
-
         // IR file name defaults to {languageName}.ir.json if not already set
         if (!properties.containsKey("yajco.ir.file") && !lang.name().isEmpty()) {
             properties.setProperty("yajco.ir.file", lang.name() + ".ir.json");
         }
-    }
-
-    /**
-     * Generates skip rules from {@code @Language} comment syntax and adds them
-     * to the parser's skip list. This allows users to specify comment syntax once
-     * in {@code @Language} without needing a separate {@code @Skip} annotation.
-     *
-     * @param element The element annotated with @Language.
-     * @param existingSkips The skip list from @Parser to check for duplicates.
-     * @return Additional SkipDef entries to add to the language.
-     */
-    private List<SkipDef> buildCommentSkipsFromLanguage(Element element, List<SkipDef> existingSkips) {
-        yajco.annotation.config.Language lang = element.getAnnotation(yajco.annotation.config.Language.class);
-        if (lang == null) {
-            return Collections.emptyList();
-        }
-
-        // Collect existing skip patterns to avoid duplicates
-        Set<String> existingPatterns = new HashSet<>();
-        for (SkipDef skip : existingSkips) {
-            existingPatterns.add(skip.getRegexp());
-        }
-
-        List<SkipDef> commentSkips = new ArrayList<>();
-
-        // Line comment: prefix → prefix + ".*"
-        if (!lang.lineComment().isEmpty()) {
-            String pattern = escapeRegex(lang.lineComment()) + ".*";
-            if (!existingPatterns.contains(pattern)) {
-                commentSkips.add(new SkipDef(pattern));
-            }
-        }
-
-        // Block comment: [start, end] → start + "(?:(?!" + end + ")[\\s\\S])*" + end
-        if (lang.blockComment().length == 2) {
-            String start = escapeRegex(lang.blockComment()[0]);
-            String end = escapeRegex(lang.blockComment()[1]);
-            String pattern = start + "(?:(?!" + end + ")[\\s\\S])*" + end;
-            if (!existingPatterns.contains(pattern)) {
-                commentSkips.add(new SkipDef(pattern));
-            }
-        }
-
-        return commentSkips;
     }
 
     /**
@@ -269,6 +216,9 @@ public class LanguageModelBuilder {
     /**
      * Adds tokens and skips defined in @Parser annotation into language.
      * Also adds comment skip rules from @Language if present.
+     * Extracts comment metadata from {@code @Skip(lineComment=...)} and
+     * {@code @Skip(blockComment=...)} entries in {@code @Parser.skips()} and stores
+     * them as IR properties.
      *
      * @param parserAnnotation @Parser annotation object
      * @param parserAnnotationElement The annotated element (for reading @Language)
@@ -280,8 +230,15 @@ public class LanguageModelBuilder {
             tokens.add(new TokenDef(tokenDef.name(), tokenDef.regexp(), tokenDef));
         }
         for (Skip skip : parserAnnotation.skips()) {
-            String regexp = convertSkipToRegexp(skip);
-            skips.add(new SkipDef(regexp, skip));
+            SkipConversionResult conversion = convertSkip(skip, parserAnnotationElement);
+            skips.add(new SkipDef(conversion.regexp, skip));
+            if (conversion.lineComment != null) {
+                properties.setProperty("yajco.ir.lineComment", conversion.lineComment);
+            }
+            if (conversion.blockCommentStart != null) {
+                properties.setProperty("yajco.ir.blockComment.start", conversion.blockCommentStart);
+                properties.setProperty("yajco.ir.blockComment.end", conversion.blockCommentEnd);
+            }
         }
 
         // Add default white space for skips if empty.
@@ -289,47 +246,76 @@ public class LanguageModelBuilder {
             skips.add(new SkipDef("\\s"));
         }
 
-        // Add comment skip rules from @Language (avoids duplicate @Skip for comments)
-        List<SkipDef> commentSkips = buildCommentSkipsFromLanguage(parserAnnotationElement, skips);
-        skips.addAll(commentSkips);
-
         addToListAsSet(language.getSkips(), skips, true);
         addToListAsSet(language.getTokens(), tokens, true);
     }
 
+    private static final class SkipConversionResult {
+        private final String regexp;
+        private final String lineComment;
+        private final String blockCommentStart;
+        private final String blockCommentEnd;
+
+        private SkipConversionResult(String regexp, String lineComment, String blockCommentStart, String blockCommentEnd) {
+            this.regexp = regexp;
+            this.lineComment = lineComment;
+            this.blockCommentStart = blockCommentStart;
+            this.blockCommentEnd = blockCommentEnd;
+        }
+    }
+
     /**
-     * Converts @Skip annotation parameters into a regular expression.
-     * Supports syntactic sugar for whitespace and comment patterns.
+     * Converts @Skip annotation parameters into parser skip regexp and optional
+     * IR comment metadata.
      *
      * @param skip @Skip annotation object
-     * @return Regular expression string
+     * @param element The annotated element, used for error reporting
+     * @return Skip conversion output containing regexp and optional comment metadata
      */
-    private String convertSkipToRegexp(Skip skip) {
+    private SkipConversionResult convertSkip(Skip skip, Element element) {
         // If value is explicitly set, use it directly (highest priority)
         if (!skip.value().isEmpty()) {
-            return skip.value();
+            return new SkipConversionResult(skip.value(), null, null, null);
         }
 
         // Handle whitespace flag
         if (skip.whitespace()) {
-            return "\\s";
+            return new SkipConversionResult("\\s", null, null, null);
         }
 
-        // Handle comment patterns with start and optional end
+        // Handle line comment: prefix → "prefix.*"
+        if (!skip.lineComment().isEmpty()) {
+            return new SkipConversionResult(escapeRegex(skip.lineComment()) + ".*", skip.lineComment(), null, null);
+        }
+
+        // Handle block comment: [start, end] → "start(?:(?!end)[\s\S])*end"
+        if (skip.blockComment().length != 0) {
+            if (skip.blockComment().length != 2) {
+                error("@Skip blockComment must have exactly 2 elements: {start, end}, e.g. {\"/*\", \"*/\"}.", element);
+                return new SkipConversionResult("", null, null, null);
+            }
+            String start = escapeRegex(skip.blockComment()[0]);
+            String end = escapeRegex(skip.blockComment()[1]);
+            return new SkipConversionResult(
+                start + "(?:(?!" + end + ")[\\s\\S])*" + end,
+                null,
+                skip.blockComment()[0],
+                skip.blockComment()[1]);
+        }
+
+        // Handle deprecated comment patterns with start and optional end
         if (!skip.start().isEmpty()) {
             String start = escapeRegex(skip.start());
             if (!skip.end().isEmpty()) {
-                // Multi-line comment with explicit end: start...end
                 String end = escapeRegex(skip.end());
-                return start + "(?:(?!" + end + ")[\\s\\S])*" + end;
+                return new SkipConversionResult(start + "(?:(?!" + end + ")[\\s\\S])*" + end, null, skip.start(), skip.end());
             } else {
-                // Single-line comment: start until end of line
-                return start + ".*";
+                return new SkipConversionResult(start + ".*", skip.start(), null, null);
             }
         }
 
         // If nothing is specified, return empty string (should not happen in practice)
-        return "";
+        return new SkipConversionResult("", null, null, null);
     }
 
     /**
@@ -342,6 +328,17 @@ public class LanguageModelBuilder {
         return literal.replaceAll("([\\\\.*+?^${}()|\\[\\]])", "\\\\$1");
     }
 
+
+    /**
+     * Reports a compilation error via the annotation processing {@link javax.annotation.processing.Messager}.
+     * The error is attached to the given element, so IDEs and javac can point to the exact location.
+     *
+     * @param message Error message to display
+     * @param element The annotated element where the error occurred
+     */
+    private void error(String message, Element element) {
+        processingEnv.getMessager().printMessage(javax.tools.Diagnostic.Kind.ERROR, message, element);
+    }
 
     /**
      * Processes language model elements.

--- a/yajco-annotation-processor/src/test/java/yajco/annotation/processor/AnnotationProcessorLanguageModelTest.java
+++ b/yajco-annotation-processor/src/test/java/yajco/annotation/processor/AnnotationProcessorLanguageModelTest.java
@@ -85,11 +85,16 @@ public class AnnotationProcessorLanguageModelTest {
                 + "    name = \"robot\",\n"
                 + "    description = \"Robot commands\",\n"
                 + "    version = \"1.0\",\n"
-                + "    fileExtensions = {\".robot\"},\n"
-                + "    lineComment = \"//\",\n"
-                + "    blockComment = {\"/*\", \"*/\"}\n"
+                + "    fileExtensions = {\".robot\"}\n"
                 + ")\n"
-                + "@Parser(options = @Option(name = \"yajco.generateParser\", value = \"false\"))\n"
+                + "@Parser(\n"
+                + "    skips = {\n"
+                + "        @Skip(whitespace=true),\n"
+                + "        @Skip(lineComment=\"//\"),\n"
+                + "        @Skip(blockComment={\"/*\", \"*/\"})\n"
+                + "    },\n"
+                + "    options = @Option(name = \"yajco.generateParser\", value = \"false\")\n"
+                + ")\n"
                 + "public class Robot {\n"
                 + "    public Robot() {\n"
                 + "    }\n"
@@ -534,5 +539,26 @@ public class AnnotationProcessorLanguageModelTest {
     private static void assertReferenceToConcept(Concept concept, Type type) {
         assertEquals(ReferenceType.class, type.getClass());
         assertEquals(concept, ((ReferenceType) type).getConcept());
+    }
+
+    @Test
+    public void shouldReportErrorForSkipBlockCommentWithWrongNumberOfElements() throws Exception {
+        List<javax.tools.Diagnostic<? extends javax.tools.JavaFileObject>> errors =
+            compiler.compileExpectingErrors(
+                source("test.robot.Robot",
+                    "package test.robot;\n"
+                        + "import yajco.annotation.config.*;\n"
+                        + "@Parser(\n"
+                        + "    skips = { @Skip(blockComment={\"/*\"}) },\n"
+                        + "    options = @Option(name = \"yajco.generateParser\", value = \"false\")\n"
+                        + ")\n"
+                        + "public class Robot {\n"
+                        + "    public Robot() {}\n"
+                        + "}\n"));
+
+        assertTrue("Expected at least one error", errors.size() >= 1);
+        boolean found = errors.stream().anyMatch(d ->
+            d.getMessage(java.util.Locale.ROOT).contains("blockComment must have exactly 2 elements"));
+        assertTrue("Expected error about blockComment element count, got: " + errors, found);
     }
 }

--- a/yajco-annotation-processor/src/test/java/yajco/annotation/processor/AnnotationProcessorTestCompiler.java
+++ b/yajco-annotation-processor/src/test/java/yajco/annotation/processor/AnnotationProcessorTestCompiler.java
@@ -11,6 +11,7 @@ import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.*;
 
+import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertTrue;
 
@@ -30,6 +31,23 @@ final class AnnotationProcessorTestCompiler {
     }
 
     Language compileAndReadLanguageModel(SourceSpec... sources) throws IOException {
+        CompilationResult result = compile(sources);
+        assertTrue(result.diagnosticsToString(), result.success);
+
+        Path modelXml = result.classOutput.toPath().resolve("META-INF/yajco-lang.xml");
+        assertTrue("Expected generated language model at " + modelXml, Files.exists(modelXml));
+        try (InputStream inputStream = Files.newInputStream(modelXml)) {
+            return XMLLanguageFormatHelper.readFromXML(inputStream);
+        }
+    }
+
+    List<Diagnostic<? extends JavaFileObject>> compileExpectingErrors(SourceSpec... sources) throws IOException {
+        CompilationResult result = compile(sources);
+        assertFalse("Expected compilation to fail, but it succeeded", result.success);
+        return result.errors();
+    }
+
+    private CompilationResult compile(SourceSpec... sources) throws IOException {
         JavaCompiler compiler = ToolProvider.getSystemJavaCompiler();
         assertNotNull("Tests must run on a JDK, not a JRE", compiler);
 
@@ -52,15 +70,40 @@ final class AnnotationProcessorTestCompiler {
                 null,
                 sourceFiles(sources));
             task.setProcessors(Collections.singletonList(new AnnotationProcessor()));
+            return new CompilationResult(task.call(), classOutput, diagnostics.getDiagnostics());
+        }
+    }
 
-            Boolean success = task.call();
-            assertTrue(diagnosticsToString(diagnostics), success);
+    private static final class CompilationResult {
+        final boolean success;
+        final File classOutput;
+        final List<Diagnostic<? extends JavaFileObject>> diagnostics;
+
+        CompilationResult(boolean success, File classOutput, List<Diagnostic<? extends JavaFileObject>> diagnostics) {
+            this.success = success;
+            this.classOutput = classOutput;
+            this.diagnostics = diagnostics;
         }
 
-        Path modelXml = classOutput.toPath().resolve("META-INF/yajco-lang.xml");
-        assertTrue("Expected generated language model at " + modelXml, Files.exists(modelXml));
-        try (InputStream inputStream = Files.newInputStream(modelXml)) {
-            return XMLLanguageFormatHelper.readFromXML(inputStream);
+        List<Diagnostic<? extends JavaFileObject>> errors() {
+            List<Diagnostic<? extends JavaFileObject>> errors = new ArrayList<>();
+            for (Diagnostic<? extends JavaFileObject> d : diagnostics) {
+                if (d.getKind() == Diagnostic.Kind.ERROR) {
+                    errors.add(d);
+                }
+            }
+            return errors;
+        }
+
+        String diagnosticsToString() {
+            StringBuilder result = new StringBuilder();
+            for (Diagnostic<? extends JavaFileObject> diagnostic : diagnostics) {
+                result.append(diagnostic.getKind())
+                    .append(": ")
+                    .append(diagnostic.getMessage(Locale.ROOT))
+                    .append(System.lineSeparator());
+            }
+            return result.toString();
         }
     }
 
@@ -96,17 +139,6 @@ final class AnnotationProcessorTestCompiler {
                 result.append(File.pathSeparator);
             }
             result.append(new File(url.getFile()).getAbsolutePath());
-        }
-        return result.toString();
-    }
-
-    private String diagnosticsToString(DiagnosticCollector<JavaFileObject> diagnostics) {
-        StringBuilder result = new StringBuilder();
-        for (Diagnostic<? extends JavaFileObject> diagnostic : diagnostics.getDiagnostics()) {
-            result.append(diagnostic.getKind())
-                .append(": ")
-                .append(diagnostic.getMessage(Locale.ROOT))
-                .append(System.lineSeparator());
         }
         return result.toString();
     }

--- a/yajco-annotations/src/main/java/yajco/annotation/config/Language.java
+++ b/yajco-annotations/src/main/java/yajco/annotation/config/Language.java
@@ -12,10 +12,6 @@ import java.lang.annotation.Target;
  * When present, IR generation is automatically enabled — there is no need to
  * add {@code @Option(name = "yajco.generateTools", value = "ir")}.
  *
- * <p>Comment syntax specified here is used both as editor metadata
- * (comment toggling, TextMate scopes) and as a parser skip rule —
- * a separate {@link Skip} for comments is not required.
- *
  * <h3>Example usage:</h3>
  * <pre>
  * &#64;Language(
@@ -23,11 +19,10 @@ import java.lang.annotation.Target;
  *     description = "A simple robot programming language",
  *     version = "1.0.0",
  *     fileExtensions = {".robot"},
- *     lineComment = "//"
  * )
  * &#64;Parser(
  *     mainNode = "Robot",
- *     skips = { &#64;Skip("\\s") }
+ *     skips = { &#64;Skip(whitespace=true), &#64;Skip(lineComment="//") }
  * )
  * package yajco.robot.model;
  * </pre>
@@ -59,19 +54,4 @@ public @interface Language {
      * Each extension should include the leading dot.
      */
     String[] fileExtensions() default {};
-
-    /**
-     * Line comment prefix (e.g. "//", "#", "--").
-     * When set, a skip rule for this comment style is automatically
-     * added to the parser and the IR's comment metadata is populated.
-     */
-    String lineComment() default "";
-
-    /**
-     * Block comment delimiters as a two-element array: {start, end}.
-     * For example: {"/*", "*&#47;"}.
-     * When set, a skip rule for block comments is automatically
-     * added to the parser and the IR's comment metadata is populated.
-     */
-    String[] blockComment() default {};
 }

--- a/yajco-annotations/src/main/java/yajco/annotation/config/Skip.java
+++ b/yajco-annotations/src/main/java/yajco/annotation/config/Skip.java
@@ -3,11 +3,71 @@ package yajco.annotation.config;
 import java.lang.annotation.Retention;
 import java.lang.annotation.RetentionPolicy;
 
+/**
+ * Declares a parser skip rule.
+ *
+ * <p>{@code @Skip} entries are used inside {@link Parser#skips()} to define
+ * ignored text such as whitespace and comments.
+ *
+ * <p>Comment-oriented forms ({@link #lineComment()} and {@link #blockComment()})
+ * are the preferred API. They both:
+ * <ul>
+ *   <li>generate parser skip regular expressions</li>
+ *   <li>provide metadata for editors and IDEs</li>
+ * </ul>
+ *
+ * <p>Evaluation priority inside one {@code @Skip} entry:
+ * {@link #value()} &gt; {@link #whitespace()} &gt; {@link #lineComment()}
+ * &gt; {@link #blockComment()} &gt; deprecated {@link #start()}/{@link #end()}.
+ */
 @Retention(RetentionPolicy.SOURCE)
 //Target: None
 public @interface Skip {
+    /**
+     * Raw regular expression to skip.
+     *
+     * <p>Use this when shorthand options are insufficient.
+     * Example: {@code @Skip("//.*")}.
+     */
     String value() default "";
-    String start() default "";
-    String end() default "";
+
+    /**
+     * Shorthand for skipping whitespace ({@code \s}).
+     * Example: {@code @Skip(whitespace = true)}.
+     */
     boolean whitespace() default false;
+
+    /**
+     * Line comment prefix (e.g. "//", "#", "--").
+     *
+     * <p>Produces skip regexp {@code escape(prefix) + ".*"} and stores the
+     * original prefix as comment metadata.
+     */
+    String lineComment() default "";
+
+    /**
+     * Block comment delimiters as a two-element array: {start, end}.
+     * For example: {"/*", "*&#47;"}.
+     *
+     * <p>Must contain exactly two elements. Produces skip regexp
+     * {@code escape(start) + "(?:(?!" + escape(end) + ")[\\s\\S])*" + escape(end)}
+     * and stores original delimiters as comment metadata.
+     */
+    String[] blockComment() default {};
+
+    /**
+     * Deprecated block-comment start delimiter.
+     *
+     * <p>Use {@link #blockComment()} instead.
+     */
+    @Deprecated
+    String start() default "";
+
+    /**
+     * Deprecated block-comment end delimiter.
+     *
+     * <p>Use {@link #blockComment()} instead.
+     */
+    @Deprecated
+    String end() default "";
 }


### PR DESCRIPTION
Move comment syntax specification from `@Language` to `@Parser`.
Also replace `@Skip.start` and `@Skip.end` with `@Skip.lineComment` and `@Skip.blockComment`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Enhanced parser skip configuration via `@Skip`, including whitespace, line comments, and block comments.
  * Comment syntax metadata is now derived from `@Parser(skips=...)` rather than `@Language`.
* **Bug Fixes**
  * Added validation for `@Skip(blockComment=...)` delimiter count with clearer compiler errors for invalid configurations.
* **Documentation**
  * Updated user guide and annotation docs to reflect the new structured `@Skip` options and deprecated legacy `start/end` syntax.
* **Tests**
  * Improved compiler test utilities and added coverage for invalid block comment configurations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->