### PR TITLE
Replace google-java-format with javaparser pretty-printer

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -81,7 +81,7 @@
     <velocity.version>2.4.1</velocity.version>
     <slf4j.version>2.0.16</slf4j.version>
     <xstream.version>1.4.21</xstream.version>
-    <google-java-format.version>1.21.0</google-java-format.version>
+    <javaparser.version>3.28.2</javaparser.version>
   </properties>
 
   <modules>
@@ -109,9 +109,9 @@
         <version>${jspecify.version}</version>
       </dependency>
       <dependency>
-        <groupId>com.google.googlejavaformat</groupId>
-        <artifactId>google-java-format</artifactId>
-        <version>${google-java-format.version}</version>
+        <groupId>com.github.javaparser</groupId>
+        <artifactId>javaparser-core</artifactId>
+        <version>${javaparser.version}</version>
       </dependency>
       <dependency>
         <groupId>org.apache.velocity</groupId>

--- a/yajco-modules/yajco-generator-module/pom.xml
+++ b/yajco-modules/yajco-generator-module/pom.xml
@@ -20,8 +20,8 @@
       <version>${project.version}</version>
     </dependency>
     <dependency>
-      <groupId>com.google.googlejavaformat</groupId>
-      <artifactId>google-java-format</artifactId>
+      <groupId>com.github.javaparser</groupId>
+      <artifactId>javaparser-core</artifactId>
     </dependency>
   </dependencies>
 </project>

--- a/yajco-modules/yajco-generator-module/src/main/java/yajco/generator/util/Utilities.java
+++ b/yajco-modules/yajco-generator-module/src/main/java/yajco/generator/util/Utilities.java
@@ -1,7 +1,10 @@
 package yajco.generator.util;
 
-import com.google.googlejavaformat.java.Formatter;
-import com.google.googlejavaformat.java.FormatterException;
+import com.github.javaparser.JavaParser;
+import com.github.javaparser.ParseResult;
+import com.github.javaparser.ParserConfiguration;
+import com.github.javaparser.ast.CompilationUnit;
+import com.github.javaparser.printer.DefaultPrettyPrinter;
 import yajco.generator.GeneratorException;
 import yajco.model.*;
 import yajco.model.type.*;
@@ -12,7 +15,7 @@ import java.util.*;
 
 public class Utilities {
 
-    private static Formatter formatter;
+    private static JavaParser parser;
 
     public static String toUpperCaseIdent(String ident) {
         return Character.toUpperCase(ident.charAt(0)) + ident.substring(1);
@@ -81,16 +84,17 @@ public class Utilities {
 
     public static void formatCode(File file) {
         try {
-            Formatter formatter = getFormatter();
             String source = java.nio.file.Files.readString(file.toPath());
-            String formatted = formatter.formatSource(source);
+            ParseResult<CompilationUnit> parseResult = getParser().parse(source);
+            if (!parseResult.isSuccessful() || !parseResult.getResult().isPresent()) {
+                throw new GeneratorException("Error formatting file " + file.getAbsolutePath() + ": cannot parse Java source");
+            }
+            String formatted = new DefaultPrettyPrinter().print(parseResult.getResult().get());
             java.nio.file.Files.writeString(file.toPath(), formatted);
         } catch (FileNotFoundException ex) {
             throw new GeneratorException("File " + file.getAbsolutePath() + " is not available", ex);
         } catch (java.io.IOException ex) {
             throw new GeneratorException("Error reading or writing file " + file.getAbsolutePath(), ex);
-        } catch (FormatterException ex) {
-            throw new GeneratorException("Error formatting file " + file.getAbsolutePath(), ex);
         }
     }
 
@@ -206,11 +210,11 @@ public class Utilities {
         return str.toString();
     }
 
-    private synchronized static Formatter getFormatter() {
-        if (formatter == null) {
-            formatter = new Formatter();
+    private synchronized static JavaParser getParser() {
+        if (parser == null) {
+            parser = new JavaParser(new ParserConfiguration().setLanguageLevel(ParserConfiguration.LanguageLevel.JAVA_11));
         }
-        return formatter;
+        return parser;
     }
 
     public static String encodeStringIntoTokenName(String s) {


### PR DESCRIPTION
`google-java-format` required access to internal JDK APIs and caused build errors in JDK >= 16. This should resolve the issue described in kpi-tuke/yajco-examples#17 without changing compiler arguments.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Improvements**
  - Java source formatting has been updated to provide consistent output through an enhanced parsing and pretty-printing process.
  - Formatting now supports Java 11 syntax more reliably.
  - Clearer errors are reported when source files are missing, unreadable, or cannot be parsed.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->