### PR TITLE
Move Parser interface into yajco-runtime and add ParserFactory

### DIFF
--- a/yajco-modules/yajco-antlr4-parser-generator-module/src/main/resources/yajco/generator/parsergen/antlr4/templates/ParseException.java.vm
+++ b/yajco-modules/yajco-antlr4-parser-generator-module/src/main/resources/yajco/generator/parsergen/antlr4/templates/ParseException.java.vm
@@ -1,6 +1,6 @@
 package $parserPackageName;
 
-public class ParseException extends yajco.generator.parsergen.ParseException {
+public class ParseException extends yajco.parser.ParseException {
     public ParseException(String message, Throwable cause) {
         super(message, cause);
     }

--- a/yajco-modules/yajco-antlr4-parser-generator-module/src/main/resources/yajco/generator/parsergen/antlr4/templates/Parser.java.vm
+++ b/yajco-modules/yajco-antlr4-parser-generator-module/src/main/resources/yajco/generator/parsergen/antlr4/templates/Parser.java.vm
@@ -6,7 +6,7 @@ import org.antlr.v4.runtime.CommonTokenStream;
 import org.antlr.v4.runtime.BailErrorStrategy;
 import org.antlr.v4.runtime.misc.ParseCancellationException;
 
-public class $parserClassName implements yajco.generator.parsergen.Parser<$mainElementClassName, ParseException> {
+public class $parserClassName implements yajco.parser.Parser<$mainElementClassName, ParseException> {
     @Override
     public $mainElementClassName parse(String input) throws ParseException {
         TokenSource lexer = new ${ANTLRLexerFullClassName}(CharStreams.fromString(input));
@@ -30,6 +30,11 @@ public class $parserClassName implements yajco.generator.parsergen.Parser<$mainE
         } catch (java.io.IOException e) {
             throw new ParseException("Failed to read input file", e);
         }
+    }
+
+    @Override
+    public Class<$mainElementClassName> mainNodeType() {
+        return ${mainElementClassName}.class;
     }
 
     private String readAsString(java.io.Reader r) throws java.io.IOException {

--- a/yajco-modules/yajco-antlr4-parser-generator-module/src/main/resources/yajco/generator/parsergen/antlr4/templates/Parser.java.vm
+++ b/yajco-modules/yajco-antlr4-parser-generator-module/src/main/resources/yajco/generator/parsergen/antlr4/templates/Parser.java.vm
@@ -6,6 +6,7 @@ import org.antlr.v4.runtime.CommonTokenStream;
 import org.antlr.v4.runtime.BailErrorStrategy;
 import org.antlr.v4.runtime.misc.ParseCancellationException;
 
+@yajco.parser.ParserFor(${mainElementClassName}.class)
 public class $parserClassName implements yajco.parser.Parser<$mainElementClassName, ParseException> {
     @Override
     public $mainElementClassName parse(String input) throws ParseException {
@@ -30,11 +31,6 @@ public class $parserClassName implements yajco.parser.Parser<$mainElementClassNa
         } catch (java.io.IOException e) {
             throw new ParseException("Failed to read input file", e);
         }
-    }
-
-    @Override
-    public Class<$mainElementClassName> mainNodeType() {
-        return ${mainElementClassName}.class;
     }
 
     private String readAsString(java.io.Reader r) throws java.io.IOException {

--- a/yajco-modules/yajco-beaver-parser-generator-module/src/main/resources/yajco/generator/parsergen/beaver/templates/LALRParseExceptionClassTemplate.vm
+++ b/yajco-modules/yajco-beaver-parser-generator-module/src/main/resources/yajco/generator/parsergen/beaver/templates/LALRParseExceptionClassTemplate.vm
@@ -2,7 +2,7 @@
 ##Input - parserClassPackageName
 package $parserClassPackageName;
 
-public class ParseException extends yajco.generator.parsergen.ParseException {
+public class ParseException extends yajco.parser.ParseException {
     public ParseException(String message, Throwable cause) {
         super(message, cause);
     }

--- a/yajco-modules/yajco-beaver-parser-generator-module/src/main/resources/yajco/generator/parsergen/beaver/templates/LALRParserClassMetaLexerTemplate.vm
+++ b/yajco-modules/yajco-beaver-parser-generator-module/src/main/resources/yajco/generator/parsergen/beaver/templates/LALRParserClassMetaLexerTemplate.vm
@@ -10,7 +10,7 @@ package $parserClassPackageName;
 import java.io.StringReader;
 import ${parserPackageName}.$scannerClassName;
 
-public class $parserClassName implements yajco.generator.parsergen.Parser<$mainElementClassName, LALRParseException> {
+public class $parserClassName implements yajco.parser.Parser<$mainElementClassName, LALRParseException> {
     private static ${parserPackageName}.$parserClassName parser;
 
     @Override
@@ -35,5 +35,10 @@ public class $parserClassName implements yajco.generator.parsergen.Parser<$mainE
         } catch (${parserPackageName}.${parserClassName}.Exception e) {
             throw new ParseException("Problem parsing source code ", e);
         }
+    }
+
+    @Override
+    public Class<$mainElementClassName> mainNodeType() {
+        return ${mainElementClassName}.class;
     }
 }

--- a/yajco-modules/yajco-beaver-parser-generator-module/src/main/resources/yajco/generator/parsergen/beaver/templates/LALRParserClassMetaLexerTemplate.vm
+++ b/yajco-modules/yajco-beaver-parser-generator-module/src/main/resources/yajco/generator/parsergen/beaver/templates/LALRParserClassMetaLexerTemplate.vm
@@ -31,9 +31,9 @@ public class $parserClassName implements yajco.parser.Parser<$mainElementClassNa
             referenceResolver.resolveReferences();
             return root;
         } catch (java.io.IOException e) {
-            throw new ParseException("Problem parsing source code ", e);
+            throw new LALRParseException("Problem parsing source code ", e);
         } catch (${parserPackageName}.${parserClassName}.Exception e) {
-            throw new ParseException("Problem parsing source code ", e);
+            throw new LALRParseException("Problem parsing source code ", e);
         }
     }
 

--- a/yajco-modules/yajco-beaver-parser-generator-module/src/main/resources/yajco/generator/parsergen/beaver/templates/LALRParserClassMetaLexerTemplate.vm
+++ b/yajco-modules/yajco-beaver-parser-generator-module/src/main/resources/yajco/generator/parsergen/beaver/templates/LALRParserClassMetaLexerTemplate.vm
@@ -10,6 +10,7 @@ package $parserClassPackageName;
 import java.io.StringReader;
 import ${parserPackageName}.$scannerClassName;
 
+@yajco.parser.ParserFor(${mainElementClassName}.class)
 public class $parserClassName implements yajco.parser.Parser<$mainElementClassName, LALRParseException> {
     private static ${parserPackageName}.$parserClassName parser;
 
@@ -35,10 +36,5 @@ public class $parserClassName implements yajco.parser.Parser<$mainElementClassNa
         } catch (${parserPackageName}.${parserClassName}.Exception e) {
             throw new LALRParseException("Problem parsing source code ", e);
         }
-    }
-
-    @Override
-    public Class<$mainElementClassName> mainNodeType() {
-        return ${mainElementClassName}.class;
     }
 }

--- a/yajco-modules/yajco-beaver-parser-generator-module/src/main/resources/yajco/generator/parsergen/beaver/templates/LALRParserClassTemplate.vm
+++ b/yajco-modules/yajco-beaver-parser-generator-module/src/main/resources/yajco/generator/parsergen/beaver/templates/LALRParserClassTemplate.vm
@@ -9,6 +9,7 @@ package $parserClassPackageName;
 
 import ${parserPackageName}.$scannerClassName;
 
+@yajco.parser.ParserFor(${mainElementClassName}.class)
 public class $parserClassName implements yajco.parser.Parser<$mainElementClassName, ParseException> {
     private static ${parserPackageName}.$parserClassName parser;
 
@@ -48,10 +49,5 @@ public class $parserClassName implements yajco.parser.Parser<$mainElementClassNa
             sb.append(line + "\n");
         }
         return sb.toString();
-    }
-
-    @Override
-    public Class<$mainElementClassName> mainNodeType() {
-        return ${mainElementClassName}.class;
     }
 }

--- a/yajco-modules/yajco-beaver-parser-generator-module/src/main/resources/yajco/generator/parsergen/beaver/templates/LALRParserClassTemplate.vm
+++ b/yajco-modules/yajco-beaver-parser-generator-module/src/main/resources/yajco/generator/parsergen/beaver/templates/LALRParserClassTemplate.vm
@@ -9,7 +9,7 @@ package $parserClassPackageName;
 
 import ${parserPackageName}.$scannerClassName;
 
-public class $parserClassName implements yajco.generator.parsergen.Parser<$mainElementClassName, ParseException> {
+public class $parserClassName implements yajco.parser.Parser<$mainElementClassName, ParseException> {
     private static ${parserPackageName}.$parserClassName parser;
 
     @Override
@@ -48,5 +48,10 @@ public class $parserClassName implements yajco.generator.parsergen.Parser<$mainE
             sb.append(line + "\n");
         }
         return sb.toString();
+    }
+
+    @Override
+    public Class<$mainElementClassName> mainNodeType() {
+        return ${mainElementClassName}.class;
     }
 }

--- a/yajco-modules/yajco-generator-module/pom.xml
+++ b/yajco-modules/yajco-generator-module/pom.xml
@@ -20,6 +20,11 @@
       <version>${project.version}</version>
     </dependency>
     <dependency>
+      <groupId>${project.groupId}</groupId>
+      <artifactId>yajco-runtime</artifactId>
+      <version>${project.version}</version>
+    </dependency>
+    <dependency>
       <groupId>com.github.javaparser</groupId>
       <artifactId>javaparser-core</artifactId>
     </dependency>

--- a/yajco-modules/yajco-generator-module/src/main/java/yajco/generator/parsergen/CompilerGenerator.java
+++ b/yajco-modules/yajco-generator-module/src/main/java/yajco/generator/parsergen/CompilerGenerator.java
@@ -2,6 +2,7 @@ package yajco.generator.parsergen;
 
 import yajco.generator.FilesGenerator;
 import yajco.model.Language;
+import yajco.parser.Parser;
 
 import javax.annotation.processing.Filer;
 import javax.tools.FileObject;

--- a/yajco-modules/yajco-javacc-parser-generator-module/src/main/resources/yajco/generator/parsergen/javacc/templates/Parser.javavm
+++ b/yajco-modules/yajco-javacc-parser-generator-module/src/main/resources/yajco/generator/parsergen/javacc/templates/Parser.javavm
@@ -2,6 +2,7 @@
 #set( $tokenManagerClassName = $parserJavaCCPackageName + "." + $parserClassName + "TokenManager")
 package $parserPackageName;
 
+@yajco.parser.ParserFor(${mainElementName}.class)
 public class $parserClassName implements yajco.parser.Parser<$mainElementName, ParseException> {
   private static $parserJavaCCClassName _parser;
 
@@ -31,11 +32,6 @@ public class $parserClassName implements yajco.parser.Parser<$mainElementName, P
     } catch(java.io.IOException e) {
       throw new ParseException("Problem reading input file", e);
     }
-  }
-
-  @Override
-  public Class<$mainElementName> mainNodeType() {
-      return ${mainElementName}.class;
   }
 
   private String readAsString(java.io.Reader r) throws java.io.IOException {

--- a/yajco-modules/yajco-javacc-parser-generator-module/src/main/resources/yajco/generator/parsergen/javacc/templates/Parser.javavm
+++ b/yajco-modules/yajco-javacc-parser-generator-module/src/main/resources/yajco/generator/parsergen/javacc/templates/Parser.javavm
@@ -34,8 +34,8 @@ public class $parserClassName implements yajco.parser.Parser<$mainElementName, P
   }
 
   @Override
-  public Class<$mainElementClassName> mainNodeType() {
-      return ${mainElementClassName}.class;
+  public Class<$mainElementName> mainNodeType() {
+      return ${mainElementName}.class;
   }
 
   private String readAsString(java.io.Reader r) throws java.io.IOException {

--- a/yajco-modules/yajco-javacc-parser-generator-module/src/main/resources/yajco/generator/parsergen/javacc/templates/Parser.javavm
+++ b/yajco-modules/yajco-javacc-parser-generator-module/src/main/resources/yajco/generator/parsergen/javacc/templates/Parser.javavm
@@ -2,7 +2,7 @@
 #set( $tokenManagerClassName = $parserJavaCCPackageName + "." + $parserClassName + "TokenManager")
 package $parserPackageName;
 
-public class $parserClassName implements yajco.generator.parsergen.Parser<$mainElementName, ParseException> {
+public class $parserClassName implements yajco.parser.Parser<$mainElementName, ParseException> {
   private static $parserJavaCCClassName _parser;
 
   @Override
@@ -31,6 +31,11 @@ public class $parserClassName implements yajco.generator.parsergen.Parser<$mainE
     } catch(java.io.IOException e) {
       throw new ParseException("Problem reading input file", e);
     }
+  }
+
+  @Override
+  public Class<$mainElementClassName> mainNodeType() {
+      return ${mainElementClassName}.class;
   }
 
   private String readAsString(java.io.Reader r) throws java.io.IOException {

--- a/yajco-modules/yajco-javacc-parser-generator-module/src/main/resources/yajco/generator/parsergen/javacc/templates/ParserException.javavm
+++ b/yajco-modules/yajco-javacc-parser-generator-module/src/main/resources/yajco/generator/parsergen/javacc/templates/ParserException.javavm
@@ -1,6 +1,6 @@
 package $parserPackageName;
 
-public class ParseException extends yajco.generator.parsergen.ParseException {
+public class ParseException extends yajco.parser.ParseException {
   public ParseException(String message, Throwable cause) {
     super(message, cause);
   }

--- a/yajco-parser/src/main/java/yajco/parser/LALRParseException.java
+++ b/yajco-parser/src/main/java/yajco/parser/LALRParseException.java
@@ -1,6 +1,6 @@
 package yajco.parser;
 
-public class LALRParseException extends yajco.generator.parsergen.ParseException {
+public class LALRParseException extends ParseException {
     public LALRParseException(String message, Throwable cause) {
         super(message, cause);
     }

--- a/yajco-parser/src/main/java/yajco/parser/YajcoParser.java
+++ b/yajco-parser/src/main/java/yajco/parser/YajcoParser.java
@@ -2,7 +2,7 @@ package yajco.parser;
 
 import yajco.parser.beaver.YajcoParserScanner;
 
-public class YajcoParser implements yajco.generator.parsergen.Parser<yajco.model.Language, LALRParseException> {
+public class YajcoParser implements Parser<yajco.model.Language, LALRParseException> {
     private static yajco.parser.beaver.YajcoParser parser;
 
     @Override
@@ -31,6 +31,11 @@ public class YajcoParser implements yajco.generator.parsergen.Parser<yajco.model
         } catch(java.io.IOException e) {
             throw new LALRParseException("Problem reading input file", e);
         }
+    }
+
+    @Override
+    public Class<yajco.model.Language> mainNodeType() {
+        return yajco.model.Language.class;
     }
 
     private String readAsString(java.io.Reader r) throws java.io.IOException {

--- a/yajco-parser/src/main/java/yajco/parser/YajcoParser.java
+++ b/yajco-parser/src/main/java/yajco/parser/YajcoParser.java
@@ -2,6 +2,7 @@ package yajco.parser;
 
 import yajco.parser.beaver.YajcoParserScanner;
 
+@yajco.parser.ParserFor(yajco.model.Language.class)
 public class YajcoParser implements Parser<yajco.model.Language, LALRParseException> {
     private static yajco.parser.beaver.YajcoParser parser;
 
@@ -31,11 +32,6 @@ public class YajcoParser implements Parser<yajco.model.Language, LALRParseExcept
         } catch(java.io.IOException e) {
             throw new LALRParseException("Problem reading input file", e);
         }
-    }
-
-    @Override
-    public Class<yajco.model.Language> mainNodeType() {
-        return yajco.model.Language.class;
     }
 
     private String readAsString(java.io.Reader r) throws java.io.IOException {

--- a/yajco-prototype-modules/yajco-lisa-parser-generator-module/src/main/resources/yajco/generator/parsergen/lisa/templates/ParseExceptionClassTemplate.vm
+++ b/yajco-prototype-modules/yajco-lisa-parser-generator-module/src/main/resources/yajco/generator/parsergen/lisa/templates/ParseExceptionClassTemplate.vm
@@ -1,7 +1,7 @@
 ##Input - parserClassPackageName
 package $parserClassPackageName;
 
-public class LisaParseException extends yajco.generator.parsergen.ParseException {
+public class LisaParseException extends yajco.parser.ParseException {
     public LisaParseException(String message, Throwable cause) {
         super(message, cause);
     }

--- a/yajco-prototype-modules/yajco-lisa-parser-generator-module/src/main/resources/yajco/generator/parsergen/lisa/templates/ParserClassTemplate.vm
+++ b/yajco-prototype-modules/yajco-lisa-parser-generator-module/src/main/resources/yajco/generator/parsergen/lisa/templates/ParserClassTemplate.vm
@@ -7,7 +7,7 @@
 ## Input - translatorClassName
 package $parserClassPackageName;
 
-public class $parserClassName implements yajco.generator.parsergen.Parser<$mainElementClassName, LisaParseException> {
+public class $parserClassName implements yajco.parser.Parser<$mainElementClassName, LisaParseException> {
     private static ${parserPackageName}.$parserClassName parser;
 
     @Override
@@ -38,6 +38,11 @@ public class $parserClassName implements yajco.generator.parsergen.Parser<$mainE
         } catch(java.io.IOException e) {
             throw new LisaParseException("Problem reading input file", e);
         }
+    }
+
+    @Override
+    public Class<$mainElementClassName> mainNodeType() {
+        return ${mainElementClassName}.class;
     }
 
     private String readAsString(java.io.Reader r) throws java.io.IOException {

--- a/yajco-prototype-modules/yajco-lisa-parser-generator-module/src/main/resources/yajco/generator/parsergen/lisa/templates/ParserClassTemplate.vm
+++ b/yajco-prototype-modules/yajco-lisa-parser-generator-module/src/main/resources/yajco/generator/parsergen/lisa/templates/ParserClassTemplate.vm
@@ -7,6 +7,7 @@
 ## Input - translatorClassName
 package $parserClassPackageName;
 
+@yajco.parser.ParserFor(${mainElementClassName}.class)
 public class $parserClassName implements yajco.parser.Parser<$mainElementClassName, LisaParseException> {
     private static ${parserPackageName}.$parserClassName parser;
 
@@ -38,11 +39,6 @@ public class $parserClassName implements yajco.parser.Parser<$mainElementClassNa
         } catch(java.io.IOException e) {
             throw new LisaParseException("Problem reading input file", e);
         }
-    }
-
-    @Override
-    public Class<$mainElementClassName> mainNodeType() {
-        return ${mainElementClassName}.class;
     }
 
     private String readAsString(java.io.Reader r) throws java.io.IOException {

--- a/yajco-runtime/src/main/java/yajco/ParserFactory.java
+++ b/yajco-runtime/src/main/java/yajco/ParserFactory.java
@@ -1,0 +1,19 @@
+package yajco;
+
+import yajco.parser.ParseException;
+import yajco.parser.Parser;
+
+import java.util.ServiceLoader;
+
+public class ParserFactory {
+    @SuppressWarnings("unchecked")
+    public static <T> Parser<T, ? extends ParseException> getParser(Class<T> mainNodeType) {
+        ClassLoader cl = Thread.currentThread().getContextClassLoader();
+        for (var p : ServiceLoader.load(Parser.class, cl)) {
+            if (p.mainNodeType().equals(mainNodeType)) {
+                return p;
+            }
+        }
+        throw new IllegalArgumentException("No parser for " + mainNodeType.getName());
+    }
+}

--- a/yajco-runtime/src/main/java/yajco/ParserFactory.java
+++ b/yajco-runtime/src/main/java/yajco/ParserFactory.java
@@ -2,18 +2,30 @@ package yajco;
 
 import yajco.parser.ParseException;
 import yajco.parser.Parser;
+import yajco.parser.ParserFor;
 
 import java.util.ServiceLoader;
 
 public class ParserFactory {
     @SuppressWarnings("unchecked")
     public static <T> Parser<T, ? extends ParseException> getParser(Class<T> mainNodeType) {
-        ClassLoader cl = Thread.currentThread().getContextClassLoader();
-        for (var p : ServiceLoader.load(Parser.class, cl)) {
-            if (p.mainNodeType().equals(mainNodeType)) {
-                return p;
-            }
+        Parser<T, ? extends ParseException> match = ServiceLoader.load(Parser.class).stream()
+            .filter(p -> isParserFor(p.type(), mainNodeType))
+            .reduce((p1, p2) -> {
+                throw new IllegalStateException(
+                    "Cannot create the parser because multiple parser providers found for " + mainNodeType.getName()
+                    + ": " + p1.type().getName() + " and " + p2.type().getName());
+            })
+            .map(ServiceLoader.Provider::get)
+            .orElseThrow(() -> new IllegalArgumentException("No parser for " + mainNodeType.getName()));
+        return match;
+    }
+
+    private static boolean isParserFor(Class<?> parser, Class<?> mainNodeType) {
+        ParserFor annotation = parser.getAnnotation(ParserFor.class);
+        if (annotation == null) {
+            return false;
         }
-        throw new IllegalArgumentException("No parser for " + mainNodeType.getName());
+        return annotation.value().equals(mainNodeType);
     }
 }

--- a/yajco-runtime/src/main/java/yajco/parser/ParseException.java
+++ b/yajco-runtime/src/main/java/yajco/parser/ParseException.java
@@ -1,4 +1,4 @@
-package yajco.generator.parsergen;
+package yajco.parser;
 
 public class ParseException extends Exception {
     public ParseException(String message, Throwable cause) {

--- a/yajco-runtime/src/main/java/yajco/parser/Parser.java
+++ b/yajco-runtime/src/main/java/yajco/parser/Parser.java
@@ -1,4 +1,4 @@
-package yajco.generator.parsergen;
+package yajco.parser;
 
 import java.io.Reader;
 
@@ -13,4 +13,9 @@ public interface Parser<T, E extends ParseException> {
     T parse(String input) throws E;
 
     T parse(Reader reader) throws E;
+
+    /**
+     * @return Type of the main (root) node in the parsed AST
+     */
+    Class<T> mainNodeType();
 }

--- a/yajco-runtime/src/main/java/yajco/parser/Parser.java
+++ b/yajco-runtime/src/main/java/yajco/parser/Parser.java
@@ -13,9 +13,4 @@ public interface Parser<T, E extends ParseException> {
     T parse(String input) throws E;
 
     T parse(Reader reader) throws E;
-
-    /**
-     * @return Type of the main (root) node in the parsed AST
-     */
-    Class<T> mainNodeType();
 }

--- a/yajco-runtime/src/main/java/yajco/parser/ParserFactory.java
+++ b/yajco-runtime/src/main/java/yajco/parser/ParserFactory.java
@@ -1,15 +1,11 @@
-package yajco;
-
-import yajco.parser.ParseException;
-import yajco.parser.Parser;
-import yajco.parser.ParserFor;
+package yajco.parser;
 
 import java.util.ServiceLoader;
 
 public class ParserFactory {
     @SuppressWarnings("unchecked")
     public static <T> Parser<T, ? extends ParseException> getParser(Class<T> mainNodeType) {
-        Parser<T, ? extends ParseException> match = ServiceLoader.load(Parser.class).stream()
+        return ServiceLoader.load(Parser.class).stream()
             .filter(p -> isParserFor(p.type(), mainNodeType))
             .reduce((p1, p2) -> {
                 throw new IllegalStateException(
@@ -18,7 +14,6 @@ public class ParserFactory {
             })
             .map(ServiceLoader.Provider::get)
             .orElseThrow(() -> new IllegalArgumentException("No parser for " + mainNodeType.getName()));
-        return match;
     }
 
     private static boolean isParserFor(Class<?> parser, Class<?> mainNodeType) {

--- a/yajco-runtime/src/main/java/yajco/parser/ParserFor.java
+++ b/yajco-runtime/src/main/java/yajco/parser/ParserFor.java
@@ -1,0 +1,12 @@
+package yajco.parser;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+@Retention(RetentionPolicy.RUNTIME)
+@Target(ElementType.TYPE)
+public @interface ParserFor {
+    Class<?> value();
+}


### PR DESCRIPTION
`Parser` interface and `ParseException` base class are now in the `yajco-runtime`. In addition, a new `ParserFactory` class is added that allows creating instances of parsers without directly importing them. This avoids IDE errors before the parser is first generated and provides an unified interface independent of parser class name.

For example, the parser for the language with StateMachine main concept can now be created with

```java
var parser = ParserFactory.getParser(StateMachine.class);
```

To allow finding correct parser, generated parsers are annotated with `@ParserFor` annotation with main node type as an attribute:

```java
@yajco.parser.ParserFor(yajco.example.sml.model.StateMachine.class)
public class StateMachineParser implements yajco.parser.Parser<yajco.example.sml.model.StateMachine, ParseException> {
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a parser factory that automatically discovers parsers and selects one by its main node type.
  * Parsers now expose their main node type through a new API method.
  * Standardized parser and parse-exception APIs across generated parser implementations.

* **Bug Fixes**
  * Updated generated parsers and exceptions to use the shared runtime parser contracts, improving compatibility across parser generators.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->